### PR TITLE
Fix Sphinx styling and copula equations

### DIFF
--- a/docs/source/_static/css/proteus.css
+++ b/docs/source/_static/css/proteus.css
@@ -6,9 +6,13 @@
   --proteus-blue: #1d4ed8;
   --proteus-blue-soft: #eaf1ff;
   --proteus-ink: #0f172a;
+  --proteus-body: #334155;
   --proteus-muted: #526079;
   --proteus-line: #dce3ee;
   --proteus-surface: #f7f9fc;
+  --proteus-content-accent: #001a64;
+  --proteus-card-divider: #edf1f6;
+  --proteus-table-header: #eef3fb;
   --font-stack: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-stack--monospace: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   --sidebar-item-line-height: 1.35;
@@ -122,7 +126,7 @@ body {
 
 .content p,
 .content li {
-  color: #334155;
+  color: var(--proteus-body);
   line-height: 1.72;
 }
 
@@ -161,14 +165,20 @@ table.docutils {
 }
 
 table.docutils thead {
-  background: #eef3fb;
+  background: var(--proteus-table-header);
 }
 
 dl.py > dt.sig,
 dl.class > dt.sig,
 dl.method > dt.sig,
 dl.function > dt.sig {
+  box-sizing: border-box;
+  width: 100%;
+  margin-right: 0;
+  margin-left: 0;
   padding: 0.9rem 1rem;
+  text-indent: 0;
+  overflow-wrap: anywhere;
   background: var(--proteus-surface);
   border: 1px solid var(--proteus-line);
   border-left: 4px solid var(--proteus-blue);
@@ -337,7 +347,7 @@ dl.function > dt.sig {
 }
 
 .pal-card .sd-card-title {
-  color: var(--proteus-navy);
+  color: var(--proteus-content-accent);
   font-size: 1.05rem;
   font-weight: 750;
 }
@@ -351,7 +361,7 @@ dl.function > dt.sig {
 .pal-card .sd-card-footer {
   color: var(--proteus-blue);
   background: transparent;
-  border-top: 1px solid #edf1f6;
+  border-top: 1px solid var(--proteus-card-divider);
 }
 
 .pal-feature-grid {
@@ -364,7 +374,7 @@ dl.function > dt.sig {
 
 .pal-feature-grid .rubric {
   margin: 0 0 0.45rem;
-  color: var(--proteus-navy);
+  color: var(--proteus-content-accent);
   font-size: 1rem;
 }
 
@@ -413,27 +423,28 @@ dl.function > dt.sig {
 /* Dark theme */
 body[data-theme="dark"] {
   --proteus-ink: #f3f6ff;
+  --proteus-body: #c6d0df;
   --proteus-muted: #a9b6cb;
   --proteus-line: #27334b;
   --proteus-surface: #10182d;
+  --proteus-content-accent: #b8d2ff;
+  --proteus-card-divider: #27334b;
+  --proteus-table-header: #15203a;
 }
 
-body[data-theme="dark"] .content p,
-body[data-theme="dark"] .content li {
-  color: #c6d0df;
-}
-
-body[data-theme="dark"] .pal-card .sd-card-title,
-body[data-theme="dark"] .pal-feature-grid .rubric {
-  color: #b8d2ff;
-}
-
-body[data-theme="dark"] .pal-card .sd-card-footer {
-  border-top-color: var(--proteus-line);
-}
-
-body[data-theme="dark"] table.docutils thead {
-  background: #15203a;
+/* Furo's default setting is "auto". Mirror the dark palette whenever the
+   operating system requests dark colours, unless the reader selected light. */
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) {
+    --proteus-ink: #f3f6ff;
+    --proteus-body: #c6d0df;
+    --proteus-muted: #a9b6cb;
+    --proteus-line: #27334b;
+    --proteus-surface: #10182d;
+    --proteus-content-accent: #b8d2ff;
+    --proteus-card-divider: #27334b;
+    --proteus-table-header: #15203a;
+  }
 }
 
 @media (max-width: 67rem) {

--- a/src/pal/copulas.py
+++ b/src/pal/copulas.py
@@ -462,9 +462,11 @@ class GumbelCopula(ArchimedeanCopula):
         C(u_1, \ldots, u_d) = \exp\left[-\left(\sum_{i=1}^d (-\ln u_i)^\theta\right)^{1/\theta}\right]
 
     where :math:`\theta \geq 1` is the dependence parameter. The Gumbel copula
-    exhibits upper tail dependence and is part of the Archimedean family. The
-        upper tail dependence coefficient between any pair of variables in the Gumbel copula is given by:
+    exhibits upper tail dependence and is part of the Archimedean family. The upper
+    tail dependence coefficient between any pair of variables is given by:
+
     .. math::
+
         \lambda_U = 2 - 2^{1/\theta}
 
     The generator function is:
@@ -1274,16 +1276,29 @@ class ExtremalTCopula(Copula):
     multivariate extreme value copula, which is suited for modeling upper tail
     dependence between random variables.
 
-    The bivariate cumulative distribution function (CDF) of the Extremal-t copula is given by:
+    The bivariate cumulative distribution function (CDF) of the Extremal-t copula is
+    given by:
+
     .. math::
-        C(u_i, u_j) = \exp\left(
-        \ln u_i \, t_{\nu+1}\left(
-                        -\sqrt{\frac{(\nu+1)(1-\rho_{ij}^2)}}(-\ln u_i)^{-1/\nu}(-\ln u_j)^{1/\nu}}-\rho_{ij}
-                \right)
-        +\ln u_j \, t_{\nu+1}\left(
-                -\sqrt{\frac{(\nu+1)(1-\rho_{ij}^2)}}(-\ln u_j)^{-1/\nu}(-\ln u_i)^{1/\nu}}-\rho_{ij}
-                \right)
-        \right)
+
+        C(u_i, u_j)
+        &= \exp\Bigg\{
+            \ln u_i \, t_{\nu+1}\!\left(
+                \sqrt{\frac{\nu+1}{1-\rho_{ij}^2}}
+                \left[
+                    \left(\frac{-\ln u_i}{-\ln u_j}\right)^{1/\nu}
+                    - \rho_{ij}
+                \right]
+            \right) \\
+        &\qquad\quad +
+            \ln u_j \, t_{\nu+1}\!\left(
+                \sqrt{\frac{\nu+1}{1-\rho_{ij}^2}}
+                \left[
+                    \left(\frac{-\ln u_j}{-\ln u_i}\right)^{1/\nu}
+                    - \rho_{ij}
+                \right]
+            \right)
+        \Bigg\}.
 
     Its dependence structure is characterized by a correlation matrix and a degrees
     of freedom parameter :math:`\nu > 0`, which controls the strength of the


### PR DESCRIPTION
## Summary

- align Sphinx Python signature boxes with their API content
- give Furo light, dark, and automatic themes a consistent Proteus palette
- repair the Gumbel and Extremal-t copula display equations

## Root cause

The signature blocks inherited sizing and indentation that displaced their borders. Several custom documentation colours were hard-coded only for explicit dark mode, so Furo's default automatic mode mixed light and dark values. The copula docstrings also contained malformed reStructuredText indentation and an unbalanced/mis-specified Extremal-t formula.

## Validation

- `sphinx-build -b html docs/source docs/_build/html`
- `ruff check src/pal/copulas.py`
- `python -m compileall -q src/pal/copulas.py`
- parsed `proteus.css` with `tinycss2`
- checked generated Gumbel and Extremal-t HTML equations and balanced TeX delimiters

The Sphinx build completes successfully. Existing unrelated documentation warnings remain unchanged except that the affected Gumbel and Extremal-t warnings are removed.