### PR TITLE
Fix copula math rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@
 # Jobs:
 # - static-analysis: Runs linting/type checking on Python 3.13
 # - test: Runs pytest with coverage on Python 3.12 and 3.13 (matrix)
+# - docs-math: Builds the documentation and validates rendered mathematics
 # - build: Builds Python packages using standard build tool
 # - pypi-publish: Publishes to PyPI using trusted publishing (release only)
 #
@@ -85,6 +86,39 @@ jobs:
           flags: python-${{ matrix.python-version }}
           name: codecov-py${{ matrix.python-version }}
           fail_ci_if_error: false
+
+  docs-math:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Install documentation dependencies
+        run: pip install -e ".[docs]"
+
+      - name: Validate math directive structure
+        run: python scripts/check_rst_math.py src docs/source
+
+      - name: Build documentation
+        run: sphinx-build -E -b html docs/source docs/build/html
+
+      - name: Install MathJax
+        run: npm install --no-save --no-package-lock mathjax-full@3.2.2
+
+      - name: Validate rendered mathematics
+        run: node scripts/check_sphinx_math.mjs docs/build/html
 
   build:
     runs-on: ubuntu-latest

--- a/scripts/check_rst_math.py
+++ b/scripts/check_rst_math.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validate reStructuredText math directives in Python docstrings and RST files."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import sys
+from pathlib import Path
+
+MATH_DIRECTIVE = re.compile(r"^(?P<indent>[ \t]*)\.\. math::(?P<argument>[ \t]+.*)?$")
+STRING_LITERAL = re.compile(r"^(?P<prefix>[rubf]*)['\"]", re.IGNORECASE)
+DOCSTRING_NODES = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _indent_width(line: str) -> int:
+    """Return the visual width of a line's indentation."""
+    leading = line[: len(line) - len(line.lstrip(" \t"))]
+    return len(leading.expandtabs())
+
+
+def _validate_lines(lines: list[str], origin: str, first_line: int) -> tuple[int, list[str]]:
+    """Validate math directives in a sequence of reStructuredText lines."""
+    directive_count = 0
+    errors: list[str] = []
+
+    for index, line in enumerate(lines):
+        match = MATH_DIRECTIVE.match(line)
+        if match is None:
+            continue
+
+        directive_count += 1
+        line_number = first_line + index
+        location = f"{origin}:{line_number}"
+
+        if index > 0 and lines[index - 1].strip():
+            errors.append(f"{location}: math directive must be preceded by a blank line")
+
+        if match.group("argument") and match.group("argument").strip():
+            continue
+
+        if index + 1 >= len(lines) or lines[index + 1].strip():
+            errors.append(f"{location}: math directive must be followed by a blank line")
+            continue
+
+        body_index = index + 1
+        while body_index < len(lines) and not lines[body_index].strip():
+            body_index += 1
+
+        directive_indent = _indent_width(line)
+        if body_index >= len(lines) or _indent_width(lines[body_index]) <= directive_indent:
+            errors.append(f"{location}: math directive body must be non-empty and indented")
+            continue
+
+        while body_index < len(lines):
+            body_line = lines[body_index]
+            if body_line.strip() and _indent_width(body_line) <= directive_indent:
+                break
+            if "\t" in body_line:
+                errors.append(f"{origin}:{first_line + body_index}: tab character in math directive body")
+            body_index += 1
+
+    return directive_count, errors
+
+
+def _validate_python(path: Path) -> tuple[int, list[str]]:
+    """Validate math directives in every docstring in a Python file."""
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as error:
+        return 0, [f"{path}:{error.lineno}: could not parse Python source: {error.msg}"]
+
+    directive_count = 0
+    errors: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, DOCSTRING_NODES) or not node.body:
+            continue
+        expression = node.body[0]
+        if not (
+            isinstance(expression, ast.Expr)
+            and isinstance(expression.value, ast.Constant)
+            and isinstance(expression.value.value, str)
+        ):
+            continue
+
+        docstring = inspect.cleandoc(expression.value.value)
+        count, docstring_errors = _validate_lines(docstring.splitlines(), str(path), expression.lineno)
+        directive_count += count
+        errors.extend(docstring_errors)
+        if count:
+            literal = ast.get_source_segment(source, expression.value) or ""
+            literal_match = STRING_LITERAL.match(literal.lstrip())
+            if literal_match is None or "r" not in literal_match.group("prefix").lower():
+                errors.append(f"{path}:{expression.lineno}: docstring containing math directives must be a raw string")
+
+    return directive_count, errors
+
+
+def _validate_rst(path: Path) -> tuple[int, list[str]]:
+    """Validate math directives in a reStructuredText file."""
+    return _validate_lines(path.read_text(encoding="utf-8").splitlines(), str(path), 1)
+
+
+def _iter_source_files(paths: list[Path]) -> list[Path]:
+    """Expand input paths into Python and RST source files."""
+    files: set[Path] = set()
+    for path in paths:
+        if path.is_file() and path.suffix in {".py", ".rst"}:
+            files.add(path)
+        elif path.is_dir():
+            files.update(
+                candidate
+                for candidate in path.rglob("*.py")
+                if not any(part.startswith(".") for part in candidate.parts)
+            )
+            files.update(
+                candidate
+                for candidate in path.rglob("*.rst")
+                if not any(part.startswith(".") for part in candidate.parts)
+            )
+        else:
+            raise ValueError(f"source path does not exist or is unsupported: {path}")
+    return sorted(files)
+
+
+def main(arguments: list[str]) -> int:
+    """Run the directive validation command."""
+    if not arguments:
+        print("usage: check_rst_math.py PATH [PATH ...]", file=sys.stderr)
+        return 2
+
+    try:
+        files = _iter_source_files([Path(argument) for argument in arguments])
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    directive_count = 0
+    errors: list[str] = []
+    for path in files:
+        if path.suffix == ".py":
+            count, file_errors = _validate_python(path)
+        else:
+            count, file_errors = _validate_rst(path)
+        directive_count += count
+        errors.extend(file_errors)
+
+    if errors:
+        print("Invalid reStructuredText math directives:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"Validated {directive_count} math directives across {len(files)} source files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_sphinx_math.mjs
+++ b/scripts/check_sphinx_math.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/** Validate every equation emitted by Sphinx with MathJax. */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { liteAdaptor } from "mathjax-full/js/adaptors/liteAdaptor.js";
+import { RegisterHTMLHandler } from "mathjax-full/js/handlers/html.js";
+import { AllPackages } from "mathjax-full/js/input/tex/AllPackages.js";
+import { TeX } from "mathjax-full/js/input/tex.js";
+import { mathjax } from "mathjax-full/js/mathjax.js";
+import { CHTML } from "mathjax-full/js/output/chtml.js";
+
+const MATH_ELEMENT = /<(div|span)\b[^>]*class="math(?:\s[^"]*)?"[^>]*>([\s\S]*?)<\/\1>/g;
+
+function decodeHtml(value) {
+  const namedEntities = new Map([
+    ["amp", "&"],
+    ["apos", "'"],
+    ["gt", ">"],
+    ["lt", "<"],
+    ["nbsp", " "],
+    ["quot", '"'],
+  ]);
+  return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (entity, code) => {
+    if (code.startsWith("#x")) {
+      return String.fromCodePoint(Number.parseInt(code.slice(2), 16));
+    }
+    if (code.startsWith("#")) {
+      return String.fromCodePoint(Number.parseInt(code.slice(1), 10));
+    }
+    return namedEntities.get(code.toLowerCase()) ?? entity;
+  });
+}
+
+async function collectHtmlFiles(inputPath) {
+  const stat = await fs.stat(inputPath);
+  if (stat.isFile()) {
+    return inputPath.endsWith(".html") ? [inputPath] : [];
+  }
+
+  const files = [];
+  for (const entry of await fs.readdir(inputPath, { withFileTypes: true })) {
+    const entryPath = path.join(inputPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectHtmlFiles(entryPath)));
+    } else if (entry.isFile() && entry.name.endsWith(".html")) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function nearestAnchor(html, offset) {
+  const prefix = html.slice(0, offset);
+  const matches = [...prefix.matchAll(/\sid="([^"]+)"/g)];
+  return matches.at(-1)?.[1] ?? "document";
+}
+
+function unwrapFormula(value) {
+  const decoded = decodeHtml(value).trim();
+  if (decoded.startsWith("\\[") && decoded.endsWith("\\]")) {
+    return { display: true, tex: decoded.slice(2, -2).trim() };
+  }
+  if (decoded.startsWith("\\(") && decoded.endsWith("\\)")) {
+    return { display: false, tex: decoded.slice(2, -2).trim() };
+  }
+  return null;
+}
+
+async function main() {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    console.error("usage: check_sphinx_math.mjs PATH_TO_HTML_OR_DIRECTORY");
+    process.exitCode = 2;
+    return;
+  }
+
+  const htmlFiles = await collectHtmlFiles(inputPath);
+  const adaptor = liteAdaptor();
+  RegisterHTMLHandler(adaptor);
+  const tex = new TeX({ packages: AllPackages });
+  const chtml = new CHTML({ fontURL: "" });
+  const mathDocument = mathjax.document("", { InputJax: tex, OutputJax: chtml });
+
+  let formulaCount = 0;
+  const errors = [];
+  for (const htmlFile of htmlFiles) {
+    const html = await fs.readFile(htmlFile, "utf8");
+    for (const match of html.matchAll(MATH_ELEMENT)) {
+      formulaCount += 1;
+      const location = `${htmlFile}#${nearestAnchor(html, match.index)}`;
+      const formula = unwrapFormula(match[2]);
+      if (formula === null) {
+        errors.push(`${location}: math element has missing or unexpected delimiters`);
+        continue;
+      }
+      if (!formula.tex) {
+        errors.push(`${location}: empty math element`);
+        continue;
+      }
+
+      try {
+        const output = adaptor.outerHTML(mathDocument.convert(formula.tex, { display: formula.display }));
+        if (output.includes("<mjx-merror")) {
+          const preview = formula.tex.replace(/\s+/g, " ").slice(0, 160);
+          errors.push(`${location}: MathJax could not render: ${preview}`);
+        }
+      } catch (error) {
+        const preview = formula.tex.replace(/\s+/g, " ").slice(0, 160);
+        errors.push(`${location}: ${String(error)}: ${preview}`);
+      }
+    }
+  }
+
+  if (!formulaCount) {
+    errors.push(`${inputPath}: no rendered math elements found`);
+  }
+
+  if (errors.length) {
+    console.error("Invalid rendered mathematics:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Validated ${formulaCount} rendered equations across ${htmlFiles.length} HTML files with MathJax.`);
+}
+
+await main();

--- a/src/pal/copulas.py
+++ b/src/pal/copulas.py
@@ -255,6 +255,7 @@ class StudentsTCopula(EllipticalCopula):
 
     The Student's t copula exhibits symmetric tail dependence, making it useful for
     modeling joint extreme events. The upper and lower tail dependence coefficients are given by:
+
     .. math::
 
         \lambda_U = \lambda_L = 2t_{\nu+1}\left(-\sqrt{\frac{(\nu+1)(1-\rho)}{1+\rho}}\right)
@@ -356,6 +357,7 @@ class ClaytonCopula(ArchimedeanCopula):
     exhibits lower tail dependence and is part of the Archimedean family.
 
     The lower tail dependence coefficient between any pair of variables in the Clayton copula is given by:
+
     .. math::
 
         \lambda_L = 2^{-1/\theta}
@@ -548,10 +550,12 @@ class JoeCopula(ArchimedeanCopula):
 
     .. math::
 
+        \begin{aligned}
         C(u_1, \ldots, u_d)
-        = 1 - \left\{
-            1 - \prod_{i=1}^d \left[1 - (1-u_i)^\theta\right]
-          \right\}^{1/\theta}
+          &= 1 - \left\{
+              1 - \prod_{i=1}^d \left[1 - (1-u_i)^\theta\right]
+            \right\}^{1/\theta}
+        \end{aligned}
 
     where :math:`\theta \geq 1` is the dependence parameter.
 
@@ -598,15 +602,19 @@ class MM1Copula(Copula):
 
     .. math::
 
+        \begin{aligned}
         C(u_1, \ldots, u_d)
-        = \exp\left\{
-            -\left[
-                \sum_{i<j}\left\{
-                    \left(\frac{(-\ln u_i)^\theta}{d-1}\right)^{\delta_{ij}}
-                    + \left(\frac{(-\ln u_j)^\theta}{d-1}\right)^{\delta_{ij}}
-                \right\}^{1/\delta_{ij}}
-            \right]^{1/\theta}
-          \right\}
+          &= \exp\left\{
+              -\left[
+                  \sum_{i<j}\left\{
+                      \begin{aligned}
+                      &\left(\frac{(-\ln u_i)^\theta}{d-1}\right)^{\delta_{ij}} \\
+                      &\quad+ \left(\frac{(-\ln u_j)^\theta}{d-1}\right)^{\delta_{ij}}
+                      \end{aligned}
+                  \right\}^{1/\delta_{ij}}
+              \right]^{1/\theta}
+            \right\}
+        \end{aligned}
 
     for a symmetric matrix :math:`\delta_{ij} \geq 1` and
     :math:`\theta \geq 1`. The MM1 copula reduces to the Gumbel copula when all
@@ -720,7 +728,7 @@ class GalambosCopula(Copula):
 
     .. math::
 
-    C(u, v) = uv\exp\left(-\left[(-\ln u)^{-\theta} + (-\ln v)^{-\theta}\right]^{-1/\theta}\right)
+        C(u, v) = uv\exp\left(-\left[(-\ln u)^{-\theta} + (-\ln v)^{-\theta}\right]^{-1/\theta}\right)
 
     Its dependence structure is characterized by a single parameter,
     :math:`\theta > 0`, which controls the strength of the upper tail dependence.
@@ -971,20 +979,22 @@ class HuslerReissCopula(Copula):
 
     .. math::
 
+        \begin{aligned}
         C(u_i, u_j)
-        &= \exp\Bigg\{
-            \ln u_i \, \Phi\!\left(
-                \lambda_{ij}
-                + \frac{1}{2\lambda_{ij}}
-                  \ln\!\left(\frac{-\ln u_i}{-\ln u_j}\right)
-            \right) \\
-        &\qquad\quad +
-            \ln u_j \, \Phi\!\left(
-                \lambda_{ij}
-                + \frac{1}{2\lambda_{ij}}
-                  \ln\!\left(\frac{-\ln u_j}{-\ln u_i}\right)
-            \right)
-          \Bigg\}
+          &= \exp\Bigg\{
+              \ln u_i \, \Phi\!\left(
+                  \lambda_{ij}
+                  + \frac{1}{2\lambda_{ij}}
+                    \ln\!\left(\frac{-\ln u_i}{-\ln u_j}\right)
+              \right) \\
+          &\qquad\quad +
+              \ln u_j \, \Phi\!\left(
+                  \lambda_{ij}
+                  + \frac{1}{2\lambda_{ij}}
+                    \ln\!\left(\frac{-\ln u_j}{-\ln u_i}\right)
+              \right)
+            \Bigg\}
+        \end{aligned}
 
     where :math:`\Phi` is the standard normal CDF and :math:`\lambda_{ij}` is the parameter
     controlling the dependence between the two variables.
@@ -1301,24 +1311,26 @@ class ExtremalTCopula(Copula):
 
     .. math::
 
+        \begin{aligned}
         C(u_i, u_j)
-        &= \exp\Bigg\{
-            \ln u_i \, t_{\nu+1}\!\left(
-                \sqrt{\frac{\nu+1}{1-\rho_{ij}^2}}
-                \left[
-                    \left(\frac{-\ln u_i}{-\ln u_j}\right)^{1/\nu}
-                    - \rho_{ij}
-                \right]
-            \right) \\
-        &\qquad\quad +
-            \ln u_j \, t_{\nu+1}\!\left(
-                \sqrt{\frac{\nu+1}{1-\rho_{ij}^2}}
-                \left[
-                    \left(\frac{-\ln u_j}{-\ln u_i}\right)^{1/\nu}
-                    - \rho_{ij}
-                \right]
-            \right)
-        \Bigg\}.
+          &= \exp\Bigg\{
+              \ln u_i \, t_{\nu+1}\!\left(
+                  \sqrt{\frac{\nu+1}{1-\rho_{ij}^2}}
+                  \left[
+                      \left(\frac{-\ln u_i}{-\ln u_j}\right)^{1/\nu}
+                      - \rho_{ij}
+                  \right]
+              \right) \\
+          &\qquad\quad +
+              \ln u_j \, t_{\nu+1}\!\left(
+                  \sqrt{\frac{\nu+1}{1-\rho_{ij}^2}}
+                  \left[
+                      \left(\frac{-\ln u_j}{-\ln u_i}\right)^{1/\nu}
+                      - \rho_{ij}
+                  \right]
+              \right)
+            \Bigg\}.
+        \end{aligned}
 
     Its dependence structure is characterized by a correlation matrix and a degrees
     of freedom parameter :math:`\nu > 0`, which controls the strength of the


### PR DESCRIPTION
## Summary

- wrap the Joe, MM1, Hüsler–Reiss, and Extremal-t CDFs in explicit `aligned` environments
- indent the Galambos CDF as the body of its `math` directive
- add the missing blank lines before the Student-t and Clayton tail-dependence directives
- add a `docs-math` CI job that validates source directives, builds the documentation, and parses every rendered equation with MathJax

## Root cause

Some reStructuredText math directives were not structurally valid: a directive body was unindented, while two directives were not separated from the preceding paragraph by a blank line. Sphinx therefore produced an empty display block or treated the equation as ordinary text. The multiline CDFs also used alignment syntax without explicit alignment environments, relying on permissive MathJax handling.

Sphinx does not itself parse the TeX that it emits for browser-side MathJax, so a successful documentation build alone cannot detect all rendering failures.

## Automated prevention

The new `docs-math` job:

1. checks every Python docstring and RST file for malformed `math` directives, non-raw mathematical docstrings, missing blank lines, and empty or unindented bodies
2. builds the complete Sphinx HTML documentation
3. passes every emitted inline and display equation through MathJax 3.2.2 and fails on empty elements or parser errors

The repository's existing unrelated Sphinx warnings remain visible but do not block this targeted check. Once the job has completed successfully, `docs-math` can be added as a required status check in the `main` branch protection settings.

## Validation

- corrected source: 71 math directives validated
- corrected Sphinx build: 468 rendered equations across 51 HTML files parsed successfully by MathJax
- historical broken source: correctly failed on both missing blank lines and the unindented Galambos formula
- historical broken HTML: correctly failed on both empty Galambos math elements
- deliberately malformed TeX: correctly failed at the MathJax stage
- `ruff check scripts/check_rst_math.py`
- `ruff format --check scripts/check_rst_math.py`
- `python -m compileall -q scripts/check_rst_math.py`
- `node --check scripts/check_sphinx_math.mjs`
- workflow YAML parse check
- `git diff --check`

The full Sphinx build continues to emit the repository's pre-existing unrelated warnings, chiefly duplicate object descriptions and existing docstring-formatting warnings.