### PR TITLE
Fix all remaining documentation math rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,13 @@ jobs:
         run: pip install -e ".[docs]"
 
       - name: Validate math directive structure
-        run: python scripts/check_rst_math.py src docs/source
+        run: python scripts/check_rst_math.py src docs
 
       - name: Build documentation
         run: sphinx-build -E -b html docs/source docs/build/html
 
-      - name: Install MathJax
-        run: npm install --no-save --no-package-lock mathjax-full@3.2.2
+      - name: Install MathJax 4
+        run: npm install --no-save --no-package-lock @mathjax/src@4
 
       - name: Validate rendered mathematics
         run: node scripts/check_sphinx_math.mjs docs/build/html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,18 @@ myst_enable_extensions = [
     "deflist",
 ]
 
+# Keep long display equations readable on narrow screens. Sphinx 9 uses
+# MathJax 4, whose line-breaking support is configured through this block.
+mathjax4_config = {
+    "output": {
+        "displayOverflow": "linebreak",
+        "linebreaks": {
+            "inline": True,
+            "width": "100%",
+        },
+    },
+}
+
 templates_path = ["_templates"]
 exclude_patterns = []
 

--- a/docs/tutorials/coupling_groups_and_copulas.md
+++ b/docs/tutorials/coupling_groups_and_copulas.md
@@ -458,11 +458,13 @@ Compare with input: `[0.6, 0.3, 0.2], [0.4, 0.3], [0.5]` — the rank
 correlations are close but not exact due to finite sample size
 (10,000 simulations).
 
-To be completely precise, we should compare the rank correlation to the Spearman's :math:`\rho_S` of the Gaussian copula, which is related to the underlying correlation parameter :math:`r` by:
+To be completely precise, we should compare the rank correlation to the
+Spearman's {math}`\rho_S` of the Gaussian copula, which is related to the
+underlying correlation parameter {math}`r` by:
 
-.. math::
-
-  \rho_S = \frac{6}{\pi}\asin\left(\frac{r}{2}\right)
+```{math}
+\rho_S = \frac{6}{\pi}\arcsin\left(\frac{r}{2}\right)
+```
 
 
 ## 5. `generate()` vs `apply()`

--- a/docs/tutorials/reinstatement_pricing.md
+++ b/docs/tutorials/reinstatement_pricing.md
@@ -163,9 +163,9 @@ The Proportional Hazard (PH) transform is a risk-adjusted premium
 principle introduced by Wang (1995). For a loss X with survival
 function S(x), the PH premium is:
 
-$$
+```{math}
 \pi_p(X) = \int_0^\infty [S(x)]^{1/p} \, dx
-$$
+```
 
 For p = 1 this is the pure premium (expected value). Higher values
 of p place more weight on the tail, producing a larger loaded

--- a/docs/tutorials/risk_measures_and_allocation.md
+++ b/docs/tutorials/risk_measures_and_allocation.md
@@ -42,9 +42,9 @@ Acerbi (2002) showed that within the class of coherent risk measures,
 spectral risk measures are those that can be written as a weighted
 average of quantiles:
 
-$$
-ρ(X) = E[φ(F(X))  X]
-$$
+```{math}
+\rho(X) = \mathbb{E}\!\left[\phi(F(X))\,X\right]
+```
 
 where φ is a non-negative, non-decreasing weight function (the "risk
 spectrum") that integrates to 1. The non-decreasing condition ensures
@@ -58,9 +58,9 @@ to individual lines of business. The Euler (gradient) allocation
 splits the total so that each line's share equals its marginal
 contribution:
 
-$$
-C_k = E[X_k · w]
-$$
+```{math}
+C_k = \mathbb{E}\!\left[X_k \cdot w\right]
+```
 
 where w are the per-simulation weights derived from the risk measure.
 The key property is that allocations are additive: Σ C_k = ρ(X).

--- a/scripts/check_rst_math.py
+++ b/scripts/check_rst_math.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate reStructuredText math directives in Python docstrings and RST files."""
+"""Validate math markup in Python docstrings, RST files, and MyST Markdown."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from pathlib import Path
 
 MATH_DIRECTIVE = re.compile(r"^(?P<indent>[ \t]*)\.\. math::(?P<argument>[ \t]+.*)?$")
 STRING_LITERAL = re.compile(r"^(?P<prefix>[rubf]*)['\"]", re.IGNORECASE)
+MARKDOWN_FENCE = re.compile(r"^[ \t]*(?P<fence>`{3,}|~{3,}|:{3,})(?P<info>.*)$")
 DOCSTRING_NODES = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
 
 
@@ -103,23 +104,69 @@ def _validate_rst(path: Path) -> tuple[int, list[str]]:
     return _validate_lines(path.read_text(encoding="utf-8").splitlines(), str(path), 1)
 
 
+def _is_closing_fence(line: str, fence: str) -> bool:
+    """Return whether a Markdown line closes the active fenced block."""
+    stripped = line.strip()
+    return bool(stripped) and set(stripped) == {fence[0]} and len(stripped) >= len(fence)
+
+
+def _validate_markdown(path: Path) -> tuple[int, list[str]]:
+    """Validate MyST math fences and reject math markup MyST leaves literal."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    math_count = 0
+    errors: list[str] = []
+    active_fence: str | None = None
+    math_fence_line = 0
+    math_has_body = False
+
+    for index, line in enumerate(lines, start=1):
+        if active_fence is not None:
+            if _is_closing_fence(line, active_fence):
+                if math_fence_line and not math_has_body:
+                    errors.append(f"{path}:{math_fence_line}: MyST math fence must have a non-empty body")
+                active_fence = None
+                math_fence_line = 0
+                math_has_body = False
+            elif math_fence_line:
+                math_has_body = math_has_body or bool(line.strip())
+                if "\t" in line:
+                    errors.append(f"{path}:{index}: tab character in MyST math fence")
+            continue
+
+        fence_match = MARKDOWN_FENCE.match(line)
+        if fence_match is not None:
+            active_fence = fence_match.group("fence")
+            if fence_match.group("info").strip() == "{math}":
+                math_count += 1
+                math_fence_line = index
+            continue
+
+        if ".. math::" in line:
+            errors.append(f"{path}:{index}: use a fenced {{math}} directive in MyST Markdown")
+        if ":math:`" in line:
+            errors.append(f"{path}:{index}: use the MyST {{math}} role instead of the RST math role")
+        if "$$" in line:
+            errors.append(f"{path}:{index}: use a fenced {{math}} directive instead of $$ delimiters")
+
+    if active_fence is not None and math_fence_line:
+        errors.append(f"{path}:{math_fence_line}: unterminated MyST math fence")
+
+    return math_count, errors
+
+
 def _iter_source_files(paths: list[Path]) -> list[Path]:
-    """Expand input paths into Python and RST source files."""
+    """Expand input paths into Python, RST, and Markdown source files."""
     files: set[Path] = set()
     for path in paths:
-        if path.is_file() and path.suffix in {".py", ".rst"}:
+        if path.is_file() and path.suffix in {".py", ".rst", ".md"}:
             files.add(path)
         elif path.is_dir():
-            files.update(
-                candidate
-                for candidate in path.rglob("*.py")
-                if not any(part.startswith(".") for part in candidate.parts)
-            )
-            files.update(
-                candidate
-                for candidate in path.rglob("*.rst")
-                if not any(part.startswith(".") for part in candidate.parts)
-            )
+            for suffix in ("*.py", "*.rst", "*.md"):
+                files.update(
+                    candidate
+                    for candidate in path.rglob(suffix)
+                    if not any(part.startswith(".") for part in candidate.parts)
+                )
         else:
             raise ValueError(f"source path does not exist or is unsupported: {path}")
     return sorted(files)
@@ -142,13 +189,15 @@ def main(arguments: list[str]) -> int:
     for path in files:
         if path.suffix == ".py":
             count, file_errors = _validate_python(path)
-        else:
+        elif path.suffix == ".rst":
             count, file_errors = _validate_rst(path)
+        else:
+            count, file_errors = _validate_markdown(path)
         directive_count += count
         errors.extend(file_errors)
 
     if errors:
-        print("Invalid reStructuredText math directives:", file=sys.stderr)
+        print("Invalid documentation mathematics:", file=sys.stderr)
         for error in errors:
             print(f"- {error}", file=sys.stderr)
         return 1

--- a/scripts/check_rst_math.py
+++ b/scripts/check_rst_math.py
@@ -12,6 +12,7 @@ from pathlib import Path
 MATH_DIRECTIVE = re.compile(r"^(?P<indent>[ \t]*)\.\. math::(?P<argument>[ \t]+.*)?$")
 STRING_LITERAL = re.compile(r"^(?P<prefix>[rubf]*)['\"]", re.IGNORECASE)
 MARKDOWN_FENCE = re.compile(r"^[ \t]*(?P<fence>`{3,}|~{3,}|:{3,})(?P<info>.*)$")
+PLAIN_TEXT_FORMULA = re.compile(r"^[ \t]*(?:[χλρΦΣ]|[A-Za-z](?:_[A-Za-z0-9{}+\-]+)?\([^)]*\)|\\[A-Za-z]+)[^=]*=")
 DOCSTRING_NODES = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
 
 
@@ -65,6 +66,28 @@ def _validate_lines(lines: list[str], origin: str, first_line: int) -> tuple[int
     return directive_count, errors
 
 
+def _validate_plain_text_formulae(lines: list[str], origin: str, first_line: int) -> list[str]:
+    """Reject standalone formula-like text outside RST math directives."""
+    errors: list[str] = []
+    math_indent: int | None = None
+
+    for index, line in enumerate(lines):
+        directive = MATH_DIRECTIVE.match(line)
+        if directive is not None:
+            math_indent = _indent_width(line)
+            continue
+
+        if math_indent is not None:
+            if not line.strip() or _indent_width(line) > math_indent:
+                continue
+            math_indent = None
+
+        if PLAIN_TEXT_FORMULA.match(line):
+            errors.append(f"{origin}:{first_line + index}: formula-like text must use a math directive")
+
+    return errors
+
+
 def _validate_python(path: Path) -> tuple[int, list[str]]:
     """Validate math directives in every docstring in a Python file."""
     source = path.read_text(encoding="utf-8")
@@ -87,9 +110,11 @@ def _validate_python(path: Path) -> tuple[int, list[str]]:
             continue
 
         docstring = inspect.cleandoc(expression.value.value)
-        count, docstring_errors = _validate_lines(docstring.splitlines(), str(path), expression.lineno)
+        lines = docstring.splitlines()
+        count, docstring_errors = _validate_lines(lines, str(path), expression.lineno)
         directive_count += count
         errors.extend(docstring_errors)
+        errors.extend(_validate_plain_text_formulae(lines, str(path), expression.lineno))
         if count:
             literal = ast.get_source_segment(source, expression.value) or ""
             literal_match = STRING_LITERAL.match(literal.lstrip())

--- a/scripts/check_sphinx_math.mjs
+++ b/scripts/check_sphinx_math.mjs
@@ -1,17 +1,38 @@
 #!/usr/bin/env node
-/** Validate every equation emitted by Sphinx with MathJax. */
+/** Validate every equation emitted by Sphinx with MathJax 4. */
 
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { liteAdaptor } from "mathjax-full/js/adaptors/liteAdaptor.js";
-import { RegisterHTMLHandler } from "mathjax-full/js/handlers/html.js";
-import { AllPackages } from "mathjax-full/js/input/tex/AllPackages.js";
-import { TeX } from "mathjax-full/js/input/tex.js";
-import { mathjax } from "mathjax-full/js/mathjax.js";
-import { CHTML } from "mathjax-full/js/output/chtml.js";
+import { liteAdaptor } from "@mathjax/src/js/adaptors/liteAdaptor.js";
+import { RegisterHTMLHandler } from "@mathjax/src/js/handlers/html.js";
+import { TeX } from "@mathjax/src/js/input/tex.js";
+import { mathjax } from "@mathjax/src/js/mathjax.js";
+import { CHTML } from "@mathjax/src/js/output/chtml.js";
+import "@mathjax/src/js/util/asyncLoad/esm.js";
+import "@mathjax/src/js/input/tex/ams/AmsConfiguration.js";
+import "@mathjax/src/js/input/tex/base/BaseConfiguration.js";
+import "@mathjax/src/js/input/tex/newcommand/NewcommandConfiguration.js";
+import "@mathjax/src/js/input/tex/textmacros/TextMacrosConfiguration.js";
 
 const MATH_ELEMENT = /<(div|span)\b[^>]*class="math(?:\s[^"]*)?"[^>]*>([\s\S]*?)<\/\1>/g;
+const MATHJAX_4_SCRIPT = /<script\b[^>]*\bsrc="[^"]*mathjax@4\/[^"]*"[^>]*>/i;
+const MATHJAX_LINE_BREAKING = '"displayOverflow": "linebreak"';
+const GENERATED_SOURCE_DIRECTORIES = new Set(["_modules", "_sources"]);
+const LEAKED_MATH_MARKUP = [
+  {
+    pattern: /<p>\s*\.\.\s+math::/gi,
+    problem: "unprocessed reStructuredText math directive",
+  },
+  {
+    pattern: /:math:\s*<code\b/gi,
+    problem: "unprocessed reStructuredText inline math role",
+  },
+  {
+    pattern: /<p>\s*\$\$[\s\S]*?\$\$\s*<\/p>/gi,
+    problem: "unprocessed dollar-delimited display math",
+  },
+];
 
 function decodeHtml(value) {
   const namedEntities = new Map([
@@ -42,7 +63,7 @@ async function collectHtmlFiles(inputPath) {
   const files = [];
   for (const entry of await fs.readdir(inputPath, { withFileTypes: true })) {
     const entryPath = path.join(inputPath, entry.name);
-    if (entry.isDirectory()) {
+    if (entry.isDirectory() && !GENERATED_SOURCE_DIRECTORIES.has(entry.name)) {
       files.push(...(await collectHtmlFiles(entryPath)));
     } else if (entry.isFile() && entry.name.endsWith(".html")) {
       files.push(entryPath);
@@ -79,14 +100,27 @@ async function main() {
   const htmlFiles = await collectHtmlFiles(inputPath);
   const adaptor = liteAdaptor();
   RegisterHTMLHandler(adaptor);
-  const tex = new TeX({ packages: AllPackages });
+  const tex = new TeX({ packages: ["base", "ams", "newcommand", "textmacros"] });
   const chtml = new CHTML({ fontURL: "" });
   const mathDocument = mathjax.document("", { InputJax: tex, OutputJax: chtml });
 
   let formulaCount = 0;
+  let foundMathJax4 = false;
+  let foundLineBreaking = false;
   const errors = [];
   for (const htmlFile of htmlFiles) {
     const html = await fs.readFile(htmlFile, "utf8");
+    foundMathJax4 ||= MATHJAX_4_SCRIPT.test(html);
+    foundLineBreaking ||= html.includes(MATHJAX_LINE_BREAKING);
+
+    for (const check of LEAKED_MATH_MARKUP) {
+      check.pattern.lastIndex = 0;
+      for (const match of html.matchAll(check.pattern)) {
+        const location = `${htmlFile}#${nearestAnchor(html, match.index)}`;
+        errors.push(`${location}: ${check.problem}`);
+      }
+    }
+
     for (const match of html.matchAll(MATH_ELEMENT)) {
       formulaCount += 1;
       const location = `${htmlFile}#${nearestAnchor(html, match.index)}`;
@@ -101,7 +135,8 @@ async function main() {
       }
 
       try {
-        const output = adaptor.outerHTML(mathDocument.convert(formula.tex, { display: formula.display }));
+        const node = await mathDocument.convertPromise(formula.tex, { display: formula.display });
+        const output = adaptor.outerHTML(node);
         if (output.includes("<mjx-merror")) {
           const preview = formula.tex.replace(/\s+/g, " ").slice(0, 160);
           errors.push(`${location}: MathJax could not render: ${preview}`);
@@ -115,6 +150,13 @@ async function main() {
 
   if (!formulaCount) {
     errors.push(`${inputPath}: no rendered math elements found`);
+  } else {
+    if (!foundMathJax4) {
+      errors.push(`${inputPath}: generated documentation does not load MathJax 4`);
+    }
+    if (!foundLineBreaking) {
+      errors.push(`${inputPath}: generated documentation does not enable MathJax line breaking`);
+    }
   }
 
   if (errors.length) {

--- a/src/pal/copulas.py
+++ b/src/pal/copulas.py
@@ -1207,14 +1207,16 @@ class HuslerReissCopula(Copula):
 
     @property
     def tail_dependence_matrix(self) -> npt.NDArray[np.floating]:
-        """Calculate the upper tail dependence matrix for the Hüsler-Reiss copula.
+        r"""Calculate the upper tail dependence matrix for the Hüsler-Reiss copula.
 
-        The upper tail dependence coefficient between any pair of variables i and j in
-        the Hüsler-Reiss copula is given by:
+        The upper tail dependence coefficient between any pair of variables
+        :math:`i` and :math:`j` in the Hüsler-Reiss copula is given by:
 
-        χ_ij = 2 * (1 - Phi( λ_ij  )),
+        .. math::
 
-        where Phi is the standard normal CDF.
+            \chi_{ij} = 2\left(1 - \Phi(\lambda_{ij})\right)
+
+        where :math:`\Phi` is the standard normal CDF.
 
         Returns:
             npt.NDArray[np.floating]: A 2D array representing the upper tail dependence
@@ -1229,20 +1231,25 @@ class HuslerReissCopula(Copula):
     def calculate_lambda_from_tail_dependence(
         tail_dependence_matrix: npt.NDArray[np.floating],
     ) -> npt.NDArray[np.floating]:
-        """Calculate the lambda matrix from a given upper tail dependence matrix.
+        r"""Calculate the lambda matrix from a given upper tail dependence matrix.
 
-        The upper tail dependence coefficient between any pair of variables i and j in
-        the Hüsler-Reiss copula is given by:
+        The upper tail dependence coefficient between any pair of variables
+        :math:`i` and :math:`j` in the Hüsler-Reiss copula is given by:
 
-        χ_ij = 2 * (1 - Phi( λ_ij  )),
+        .. math::
 
-        where Phi is the standard normal CDF.
+            \chi_{ij} = 2\left(1 - \Phi(\lambda_{ij})\right)
+
+        where :math:`\Phi` is the standard normal CDF.
 
         This method inverts the above relationship to compute the lambda matrix from
         the provided upper tail dependence coefficients.
-        λ_ij = Phi^(-1)(1 - χ_ij / 2)
 
-        where Phi^(-1) is the inverse standard normal CDF.
+        .. math::
+
+            \lambda_{ij} = \Phi^{-1}\left(1 - \frac{\chi_{ij}}{2}\right)
+
+        where :math:`\Phi^{-1}` is the inverse standard normal CDF.
 
         Args:
             tail_dependence_matrix (npt.NDArray[np.floating]): A 2D array
@@ -1260,14 +1267,16 @@ class HuslerReissCopula(Copula):
 
     @classmethod
     def from_tail_dependence_matrix(cls, tail_dependence_matrix: npt.NDArray[np.floating]) -> HuslerReissCopula:
-        """Create a Hüsler-Reiss copula from a given upper tail dependence matrix.
+        r"""Create a Hüsler-Reiss copula from a given upper tail dependence matrix.
 
-        The upper tail dependence coefficient between any pair of variables i and j in
-        the Hüsler-Reiss copula is given by:
+        The upper tail dependence coefficient between any pair of variables
+        :math:`i` and :math:`j` in the Hüsler-Reiss copula is given by:
 
-        χ_ij = 2 * (1 - Phi( λ_ij  )),
+        .. math::
 
-        where Phi is the standard normal CDF.
+            \chi_{ij} = 2\left(1 - \Phi(\lambda_{ij})\right)
+
+        where :math:`\Phi` is the standard normal CDF.
 
         Args:
             tail_dependence_matrix (npt.NDArray[np.floating]): A 2D array
@@ -1571,15 +1580,19 @@ class ExtremalTCopula(Copula):
         tail_dependence_matrix: npt.NDArray[np.floating],
         nu: float,
     ) -> ExtremalTCopula:
-        """Create an Extremal-t copula from a given upper tail dependence matrix.
+        r"""Create an Extremal-t copula from a given upper tail dependence matrix.
 
-        The upper tail dependence coefficient between any pair of variables i and j in
-        the Extremal-t copula is given by:
+        The upper tail dependence coefficient between any pair of variables
+        :math:`i` and :math:`j` in the Extremal-t copula is given by:
 
-        χ_ij = 2 * t_{nu+1}(-sqrt((nu+1)(1-rho_ij)/(1+rho_ij))),
+        .. math::
 
-        where t_{nu+1} is the CDF of a univariate t-distribution with nu+1 degrees of
-        freedom and rho_ij is the correlation between variables i and j.
+            \chi_{ij} = 2 \, t_{\nu+1}\left(-\sqrt{
+            \frac{(\nu+1)(1-\rho_{ij})}{1+\rho_{ij}}}\right)
+
+        where :math:`t_{\nu+1}` is the CDF of a univariate t-distribution with
+        :math:`\nu+1` degrees of freedom and :math:`\rho_{ij}` is the correlation
+        between variables :math:`i` and :math:`j`.
 
         This method inverts the above relationship to compute the correlation matrix
         from the provided upper tail dependence coefficients.

--- a/src/pal/copulas.py
+++ b/src/pal/copulas.py
@@ -351,7 +351,7 @@ class ClaytonCopula(ArchimedeanCopula):
 
     .. math::
 
-        C(u_1, \ldots, u_n) = \left(\sum_{i=1}^d u_i^{-\theta} - n + 1\right)^{-1/\theta}
+        C(u_1, \ldots, u_d) = \left(\sum_{i=1}^d u_i^{-\theta} - d + 1\right)^{-1/\theta}
 
     where :math:`\theta \geq 0` is the dependence parameter. The Clayton copula
     exhibits lower tail dependence and is part of the Archimedean family.
@@ -728,7 +728,12 @@ class GalambosCopula(Copula):
 
     .. math::
 
-        C(u, v) = uv\exp\left(-\left[(-\ln u)^{-\theta} + (-\ln v)^{-\theta}\right]^{-1/\theta}\right)
+        \begin{aligned}
+        C(u, v)
+          &= uv\exp\!\left\{
+              \left[(-\ln u)^{-\theta} + (-\ln v)^{-\theta}\right]^{-1/\theta}
+            \right\}
+        \end{aligned}
 
     Its dependence structure is characterized by a single parameter,
     :math:`\theta > 0`, which controls the strength of the upper tail dependence.

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -1339,7 +1339,10 @@ class Uniform(DistributionBase):
     r"""Uniform Distribution.
 
     Defined by:
-        F(x) = (x - a) / (b - a), for a <= x <= b
+
+    .. math::
+
+        F(x) = \frac{x-a}{b-a}, \qquad a \leq x \leq b
 
     Parameters:
         a (float): Lower bound.


### PR DESCRIPTION
## Summary

- correct the Galambos CDF, including the sign of its exponent, and make the Clayton CDF notation dimensionally consistent
- convert remaining unsupported Markdown equations and inline roles to MyST math markup
- render the Extremal-t and Hüsler–Reiss tail-dependence formulae in helper methods as proper Sphinx math
- convert a similar Uniform-distribution formula to a math directive
- add source detection for formula-like prose that would otherwise bypass MathJax
- enable MathJax 4 line breaking for long equations

## Root causes found

Some equations were not malformed TeX; they were ordinary prose such as `χ_ij = ...`. Sphinx therefore emitted them as plain text, so a rendered-equation checker could not see them. The new source check rejects this pattern and requires a math directive.

The Galambos CDF also had the wrong exponent sign. The corrected positive exponent is consistent with its upper-tail dependence coefficient `lambda_U = 2^(-1/theta)`.

## Automated prevention

The `docs-math` job now:

1. validates Python docstrings, RST, and MyST Markdown source
2. rejects unsupported RST/dollar math syntax in Markdown
3. rejects formula-like prose outside math directives
4. builds the complete Sphinx site
5. rejects unprocessed math markup in generated HTML
6. parses every emitted equation with MathJax 4
7. verifies MathJax 4 responsive line breaking remains enabled

## Validation

- 81 source math directives validated across 56 files
- 520 rendered equations across 39 pages parsed successfully with MathJax 4
- historical broken Markdown and HTML fixtures fail as expected
- deliberately malformed TeX fails at the MathJax stage
- Ruff, Python compilation, Node syntax, and `git diff --check` pass

The repository’s pre-existing unrelated Sphinx warnings remain visible and non-blocking.