### PR TITLE
Add GIG, MBBEFD and noncentral chi-squared distributions

### DIFF
--- a/docs/tutorials/distributions_guide.md
+++ b/docs/tutorials/distributions_guide.md
@@ -70,6 +70,9 @@ validating simulation results.
 | `Logistic` | `mu`, `sigma` | Growth models |
 | `Uniform` | `a`, `b` | Equal-likelihood scenarios |
 | `InverseGamma` | `alpha`, `theta`, `loc=0` | Bayesian priors |
+| `GeneralizedInverseGaussian` | `p`, `chi`, `psi`, `loc=0` | Flexible positive, right-skewed risks |
+| `MBBEFD` | `g`, `b` | Property exposure rating and capped loss-to-value ratios |
+| `NonCentralChiSquared` | `df`, `nonc` | Quadratic forms and sums of squared non-zero-mean normal variables |
 | `Paralogistic` | `shape`, `scale`, `loc=0` | Heavy-tailed alternatives |
 | `InverseBurr` | `power`, `shape`, `scale`, `loc` | Flexible heavy tails |
 | `InverseParalogistic` | `shape`, `scale`, `loc=0` | Heavy-tailed alternatives |

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -689,6 +689,8 @@ class MBBEFD(DistributionBase):
     def _validated_params(self) -> tuple[t.Any, t.Any]:
         """Return parameters after checking the admissible region."""
         g, b = self._param_values
+        g = xp.asarray(g)
+        b = xp.asarray(b)
         if bool(xp.any(~xp.isfinite(g))) or bool(xp.any(g < 1)):
             raise ValueError("g must be finite and greater than or equal to 1.")
         if bool(xp.any(~xp.isfinite(b))) or bool(xp.any(b < 0)):

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -717,7 +717,7 @@ class MBBEFD(DistributionBase):
     def cdf(self, x: DistributionParameter) -> ReturnType:
         """Compute the cumulative distribution function, including the atom at one."""
         g, b = self._validated_params()
-        values = to_backend(x.values if isinstance(x, StochasticScalar) else x)
+        values = xp.asarray(x.values if isinstance(x, StochasticScalar) else x)
         degenerate = (g == 1) | (b == 0)
         b_one = xp.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
         bg_one = xp.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
@@ -742,7 +742,7 @@ class MBBEFD(DistributionBase):
     def invcdf(self, u: DistributionParameter) -> ReturnType:
         """Compute the inverse CDF, returning one across the total-loss atom."""
         g, b = self._validated_params()
-        probabilities = to_backend(u.values if isinstance(u, StochasticScalar) else u)
+        probabilities = xp.asarray(u.values if isinstance(u, StochasticScalar) else u)
         degenerate = (g == 1) | (b == 0)
         b_one = xp.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
         bg_one = xp.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
@@ -784,7 +784,7 @@ class MBBEFD(DistributionBase):
             Proportion of expected loss below the policy limit.
         """
         g, b = self._validated_params()
-        values = to_backend(x.values if isinstance(x, StochasticScalar) else x)
+        values = xp.asarray(x.values if isinstance(x, StochasticScalar) else x)
         degenerate = (g == 1) | (b == 0)
         b_one = xp.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
         bg_one = xp.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -1813,7 +1813,7 @@ class GeneralizedInverseGaussian(DistributionBase):
         return self._wrap_result(result, u)
 
     @override
-    def _generate(self, n_sims: int, rng: np.random.Generator) -> StochasticScalar:
+    def _generate(self, n_sims: int, rng: RandomGenerator) -> StochasticScalar:
         """Generate random samples using SciPy's GIG sampler."""
         p, scipy_shape, scipy_scale, loc = self._scipy_params()
         result = geninvgauss.rvs(

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -725,7 +725,7 @@ class MBBEFD(DistributionBase):
         safe_g = xp.where(degenerate, 2.0, g)
         safe_b = xp.where(degenerate | b_one | bg_one, 2.0, b)
         limit_b = xp.where(degenerate | b_one, 0.5, b)
-        with xp.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
             main = 1 - (1 - safe_b) * safe_b**values / ((safe_g - 1) * safe_b + (1 - safe_g * safe_b) * safe_b**values)
             b_limit = 1 - 1 / (1 + (g - 1) * values)
             bg_limit = 1 - limit_b**values
@@ -750,7 +750,7 @@ class MBBEFD(DistributionBase):
         safe_g = xp.where(degenerate, 2.0, g)
         safe_b = xp.where(degenerate | b_one | bg_one, 2.0, b)
         limit_b = xp.where(degenerate | b_one, 0.5, b)
-        with xp.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
             main_argument = (safe_g * safe_b - 1) / (safe_g - 1) + ((1 - safe_b) / ((1 - probabilities) * (safe_g - 1)))
             main = 1 - xp.log(main_argument) / xp.log(safe_b)
             b_limit = probabilities / ((1 - probabilities) * (safe_g - 1))
@@ -792,7 +792,7 @@ class MBBEFD(DistributionBase):
         safe_g = xp.where(degenerate, 2.0, g)
         safe_b = xp.where(degenerate | b_one | bg_one, 2.0, b)
         limit_b = xp.where(degenerate | b_one, 0.5, b)
-        with xp.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
             numerator = (safe_g - 1) * safe_b + (1 - safe_g * safe_b) * safe_b**values
             main = xp.log(numerator / (1 - safe_b)) / xp.log(safe_g * safe_b)
             b_limit = xp.log1p((safe_g - 1) * values) / xp.log(safe_g)

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -26,6 +26,7 @@ from abc import ABC
 
 import numpy as np
 import scipy.special as scipy_special
+from scipy.stats import geninvgauss
 
 # Local imports
 from ._compat import override
@@ -569,6 +570,241 @@ class Beta(DistributionBase):
         )
 
 
+class MBBEFD(DistributionBase):
+    r"""Bernegger's MBBEFD distribution on the interval :math:`[0,1]`.
+
+    This is the :math:`(g,b)` parameterisation of the Maxwell-Boltzmann,
+    Bose-Einstein and Fermi-Dirac distribution class introduced by Bernegger
+    for exposure rating. For finite :math:`g>1`, :math:`b>0`, :math:`b\ne1`
+    and :math:`gb\ne1`, its cumulative distribution function is
+
+    .. math::
+
+        F(x) =
+        \begin{cases}
+        0, & x \leq 0, \\
+        1 - \dfrac{(1-b)b^x}
+        {(g-1)b + (1-gb)b^x}, & 0 < x < 1, \\
+        1, & x \geq 1.
+        \end{cases}
+
+    The density of the continuous part on :math:`(0,1)` is
+
+    .. math::
+
+        f(x) = -\frac{(1-b)(g-1)\log(b)b^{1+x}}
+        {\left((g-1)b+(1-gb)b^x\right)^2}.
+
+    There is also an atom at total loss:
+
+    .. math::
+
+        \Pr(X=1)=\frac{1}{g},
+        \qquad F(1^-)=1-\frac{1}{g}.
+
+    Consequently, the quantile function in the main parameter region is
+
+    .. math::
+
+        F^{-1}(u) =
+        \begin{cases}
+        1 - \dfrac{\log\left(
+        \dfrac{gb-1}{g-1}+
+        \dfrac{1-b}{(1-u)(g-1)}
+        \right)}{\log(b)}, & 0 \leq u < 1-1/g, \\
+        1, & 1-1/g \leq u \leq 1.
+        \end{cases}
+
+    The limiting CDFs used when the main expression is indeterminate are
+
+    .. math::
+
+        F(x) = \frac{(g-1)x}{1+(g-1)x}
+        \quad (b=1),
+        \qquad
+        F(x) = 1-b^x
+        \quad (gb=1),
+
+    for :math:`0<x<1`. If :math:`g=1` or :math:`b=0`, the distribution is a
+    point mass at one.
+
+    Its exposure curve is the normalized limited expected value
+
+    .. math::
+
+        G(x) = \frac{E[\min(X,x)]}{E[X]}
+        = \frac{\log\left(
+        \dfrac{(g-1)b+(1-gb)b^x}{1-b}
+        \right)}{\log(gb)},
+        \qquad 0 \leq x \leq 1.
+
+    The corresponding mean is
+
+    .. math::
+
+        E[X] = \frac{(1-b)\log(gb)}{(1-gb)\log(b)}.
+
+    The parameters satisfy :math:`g \geq 1` and :math:`b \geq 0` and are
+    required to be finite by this implementation.
+
+    Parameters:
+        g: Reciprocal of the total-loss probability.
+        b: Shape parameter.
+
+    References:
+        Bernegger, S. (1997). The Swiss Re Exposure Curves and the MBBEFD
+        Distribution Class. ASTIN Bulletin 27(1), 99--111.
+    """
+
+    def __init__(
+        self,
+        g: DistributionParameter,
+        b: DistributionParameter,
+    ) -> None:
+        """Initialize the MBBEFD distribution.
+
+        Args:
+            g: Reciprocal of the total-loss probability.
+            b: Shape parameter.
+        """
+        super().__init__(g=g, b=b)
+
+    @classmethod
+    def from_c(cls, c: DistributionParameter) -> MBBEFD:
+        r"""Construct the one-parameter Swiss Re curve associated with :math:`c`.
+
+        The conversion is :math:`g=\exp((0.78+0.12c)c)` and
+        :math:`b=\exp(3.1-0.15(1+c)c)`.
+
+        Args:
+            c: Swiss Re curve parameter.
+
+        Returns:
+            MBBEFD distribution with the corresponding ``g`` and ``b`` values.
+        """
+        g = t.cast(DistributionParameter, np.exp((0.78 + 0.12 * c) * c))
+        b = t.cast(DistributionParameter, np.exp(3.1 - 0.15 * (1 + c) * c))
+        return cls(g=g, b=b)
+
+    def _validated_params(self) -> tuple[t.Any, t.Any]:
+        """Return parameters after checking the admissible region."""
+        g, b = self._param_values
+        if bool(np.any(~np.isfinite(g))) or bool(np.any(g < 1)):
+            raise ValueError("g must be finite and greater than or equal to 1.")
+        if bool(np.any(~np.isfinite(b))) or bool(np.any(b < 0)):
+            raise ValueError("b must be finite and greater than or equal to 0.")
+        return g, b
+
+    def _wrap_result(
+        self,
+        result: t.Any,
+        argument: DistributionParameter,
+    ) -> ReturnType:
+        """Preserve stochastic coupling for array-valued results."""
+        candidates = (argument, *self._params.values())
+        stochastic_inputs = [value for value in candidates if isinstance(value, StochasticScalar)]
+        if not stochastic_inputs:
+            return float(result)
+
+        wrapped = StochasticScalar(result)
+        for value in stochastic_inputs:
+            wrapped.coupled_variable_group.merge(value.coupled_variable_group)
+        return wrapped
+
+    @override
+    def cdf(self, x: DistributionParameter) -> ReturnType:
+        """Compute the cumulative distribution function, including the atom at one."""
+        g, b = self._validated_params()
+        values = x.values if isinstance(x, StochasticScalar) else x
+        degenerate = (g == 1) | (b == 0)
+        b_one = np.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
+        bg_one = np.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
+
+        safe_g = np.where(degenerate, 2.0, g)
+        safe_b = np.where(degenerate | b_one | bg_one, 2.0, b)
+        limit_b = np.where(degenerate | b_one, 0.5, b)
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+            main = 1 - (1 - safe_b) * safe_b**values / ((safe_g - 1) * safe_b + (1 - safe_g * safe_b) * safe_b**values)
+            b_limit = 1 - 1 / (1 + (g - 1) * values)
+            bg_limit = 1 - limit_b**values
+
+        interior = np.where(
+            degenerate,
+            0.0,
+            np.where(b_one, b_limit, np.where(bg_one, bg_limit, main)),
+        )
+        result = np.where(values <= 0, 0.0, np.where(values >= 1, 1.0, interior))
+        return self._wrap_result(result, x)
+
+    @override
+    def invcdf(self, u: DistributionParameter) -> ReturnType:
+        """Compute the inverse CDF, returning one across the total-loss atom."""
+        g, b = self._validated_params()
+        probabilities = u.values if isinstance(u, StochasticScalar) else u
+        degenerate = (g == 1) | (b == 0)
+        b_one = np.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
+        bg_one = np.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
+
+        safe_g = np.where(degenerate, 2.0, g)
+        safe_b = np.where(degenerate | b_one | bg_one, 2.0, b)
+        limit_b = np.where(degenerate | b_one, 0.5, b)
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+            main_argument = (safe_g * safe_b - 1) / (safe_g - 1) + ((1 - safe_b) / ((1 - probabilities) * (safe_g - 1)))
+            main = 1 - np.log(main_argument) / np.log(safe_b)
+            b_limit = probabilities / ((1 - probabilities) * (safe_g - 1))
+            bg_limit = np.log1p(-probabilities) / np.log(limit_b)
+
+        below_atom = np.where(
+            degenerate,
+            1.0,
+            np.where(b_one, b_limit, np.where(bg_one, bg_limit, main)),
+        )
+        result = np.where(
+            (probabilities < 0) | (probabilities > 1),
+            np.nan,
+            np.where(
+                degenerate | (probabilities >= 1 - 1 / g),
+                1.0,
+                np.where(probabilities == 0, 0.0, below_atom),
+            ),
+        )
+        return self._wrap_result(result, u)
+
+    def exposure_curve(self, x: DistributionParameter) -> ReturnType:
+        r"""Compute the normalized limited expected value curve.
+
+        The exposure curve is :math:`G(x)=E[\min(X,x)]/E[X]`.
+
+        Args:
+            x: Policy limit as a proportion of the maximum loss.
+
+        Returns:
+            Proportion of expected loss below the policy limit.
+        """
+        g, b = self._validated_params()
+        values = x.values if isinstance(x, StochasticScalar) else x
+        degenerate = (g == 1) | (b == 0)
+        b_one = np.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
+        bg_one = np.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
+
+        safe_g = np.where(degenerate, 2.0, g)
+        safe_b = np.where(degenerate | b_one | bg_one, 2.0, b)
+        limit_b = np.where(degenerate | b_one, 0.5, b)
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+            numerator = (safe_g - 1) * safe_b + (1 - safe_g * safe_b) * safe_b**values
+            main = np.log(numerator / (1 - safe_b)) / np.log(safe_g * safe_b)
+            b_limit = np.log1p((safe_g - 1) * values) / np.log(safe_g)
+            bg_limit = (1 - limit_b**values) / (1 - limit_b)
+
+        interior = np.where(
+            degenerate,
+            values,
+            np.where(b_one, b_limit, np.where(bg_one, bg_limit, main)),
+        )
+        result = np.where(values <= 0, 0.0, np.where(values >= 1, 1.0, interior))
+        return self._wrap_result(result, x)
+
+
 class LogLogistic(DistributionBase):
     r"""Log-Logistic Distribution.
 
@@ -786,6 +1022,95 @@ class Gamma(DistributionBase):
             rng.gamma(_rng_value(alpha, rng), _rng_value(theta, rng), size=n_sims) + _rng_value(loc, rng)
         )
         return result
+
+
+class NonCentralChiSquared(DistributionBase):
+    r"""Noncentral chi-squared distribution.
+
+    The noncentral chi-squared distribution with degrees of freedom
+    :math:`\nu>0` and noncentrality parameter :math:`\lambda\geq0` has density
+
+    .. math::
+
+        f(x) = \frac{1}{2}\exp\left(-\frac{x+\lambda}{2}\right)
+        \left(\frac{x}{\lambda}\right)^{\nu/4-1/2}
+        I_{\nu/2-1}\left(\sqrt{\lambda x}\right),
+        \qquad x>0,
+
+    for :math:`\lambda>0`, where :math:`I_a` is the modified Bessel function
+    of the first kind. Equivalently, its CDF can be written as the Poisson
+    mixture
+
+    .. math::
+
+        F(x) = \exp\left(-\frac{\lambda}{2}\right)
+        \sum_{j=0}^{\infty}
+        \frac{(\lambda/2)^j}{j!}
+        P\left(\frac{\nu}{2}+j,\frac{x}{2}\right),
+
+    where :math:`P(a,z)` is the regularized lower incomplete gamma function.
+    When :math:`\lambda=0`, this reduces to the central chi-squared
+    distribution. Its first two moments are
+
+    .. math::
+
+        E[X]=\nu+\lambda,
+        \qquad
+        \operatorname{Var}(X)=2(\nu+2\lambda).
+
+    Parameters:
+        df: Degrees of freedom :math:`\nu>0`.
+        nonc: Noncentrality parameter :math:`\lambda\geq0`.
+
+    Notes:
+        Random generation supports both CPU and GPU execution. CDF and inverse
+        CDF evaluation are currently supported on the CPU only.
+    """
+
+    def __init__(
+        self,
+        df: DistributionParameter,
+        nonc: DistributionParameter,
+    ) -> None:
+        """Initialize a noncentral chi-squared distribution.
+
+        Args:
+            df: Positive degrees of freedom.
+            nonc: Non-negative noncentrality parameter.
+        """
+        super().__init__(df=df, nonc=nonc)
+
+    def _validated_params(self) -> tuple[t.Any, t.Any]:
+        """Return parameters after checking the admissible region."""
+        df, nonc = self._param_values
+        if bool(xp.any(xp.asarray(df) <= 0)):
+            raise ValueError("df must be strictly positive.")
+        if bool(xp.any(xp.asarray(nonc) < 0)):
+            raise ValueError("nonc must be greater than or equal to 0.")
+        return df, nonc
+
+    @override
+    def cdf(self, x: DistributionParameter) -> ReturnType:
+        """Compute the cumulative distribution function."""
+        if xp.__name__ == "cupy":
+            raise NotImplementedError("NonCentralChiSquared CDF is not supported on GPU.")
+        df, nonc = self._validated_params()
+        return _special_call(special.chndtr, x, df, nonc)  # type: ignore[return-value]
+
+    @override
+    def invcdf(self, u: DistributionParameter) -> ReturnType:
+        """Compute the inverse cumulative distribution function."""
+        if xp.__name__ == "cupy":
+            raise NotImplementedError("NonCentralChiSquared inverse CDF is not supported on GPU.")
+        df, nonc = self._validated_params()
+        return _special_call(special.chndtrix, u, df, nonc)  # type: ignore[return-value]
+
+    @override
+    def _generate(self, n_sims: int, rng: RandomGenerator) -> StochasticScalar:
+        """Generate random samples on the backend used by the random generator."""
+        df, nonc = self._validated_params()
+        result = rng.noncentral_chisquare(_rng_value(df, rng), _rng_value(nonc, rng), size=n_sims)
+        return StochasticScalar(result)
 
 
 class InverseGamma(DistributionBase):
@@ -1338,6 +1663,170 @@ class InverseGaussian(DistributionBase):
         return StochasticScalar(x)
 
 
+class GeneralizedInverseGaussian(DistributionBase):
+    r"""Generalized inverse Gaussian distribution.
+
+    Let :math:`Y=X-\mu`, where :math:`\mu` is the location parameter. The
+    probability density function is
+
+    .. math::
+
+        f_X(x) =
+        \begin{cases}
+        \dfrac{(\psi / \chi)^{p / 2}}
+        {2K_p(\sqrt{\chi\psi})}
+        y^{p-1}
+        \exp\left[-\dfrac{1}{2}\left(
+        \dfrac{\chi}{y}+\psi y
+        \right)\right], & y>0, \\
+        0, & y\leq0,
+        \end{cases}
+
+    where :math:`p\in\mathbb{R}`, :math:`\chi>0`, :math:`\psi>0`, and
+    :math:`K_\nu` is the modified Bessel function of the second kind. All
+    power moments of :math:`Y` exist and satisfy
+
+    .. math::
+
+        E[Y^r] =
+        \left(\frac{\chi}{\psi}\right)^{r/2}
+        \frac{K_{p+r}(\sqrt{\chi\psi})}
+        {K_p(\sqrt{\chi\psi})}.
+
+    In particular,
+
+    .. math::
+
+        E[X] = \mu +
+        \sqrt{\frac{\chi}{\psi}}
+        \frac{K_{p+1}(\sqrt{\chi\psi})}
+        {K_p(\sqrt{\chi\psi})},
+
+    and
+
+    .. math::
+
+        \operatorname{Var}(X) = \frac{\chi}{\psi}
+        \left[
+        \frac{K_{p+2}(\sqrt{\chi\psi})}
+        {K_p(\sqrt{\chi\psi})}
+        -
+        \left(
+        \frac{K_{p+1}(\sqrt{\chi\psi})}
+        {K_p(\sqrt{\chi\psi})}
+        \right)^2
+        \right].
+
+    This parameterisation includes the inverse Gaussian distribution with
+    mean :math:`m` and shape :math:`\lambda_{IG}` when
+
+    .. math::
+
+        p=-\frac{1}{2},
+        \qquad \chi=\lambda_{IG},
+        \qquad \psi=\frac{\lambda_{IG}}{m^2}.
+
+    Parameters:
+        p: Index parameter :math:`p`.
+        chi: Reciprocal scale parameter :math:`\chi`.
+        psi: Scale parameter :math:`\psi`.
+        loc: Location parameter :math:`\mu` (default 0).
+
+    Notes:
+        CDF evaluation, inverse CDF evaluation, and random generation are
+        currently supported on the CPU only.
+    """
+
+    def __init__(
+        self,
+        p: DistributionParameter,
+        chi: DistributionParameter,
+        psi: DistributionParameter,
+        loc: DistributionParameter = 0.0,
+    ) -> None:
+        """Initialize generalized inverse Gaussian distribution.
+
+        Args:
+            p: Index parameter.
+            chi: Positive reciprocal scale parameter.
+            psi: Positive scale parameter.
+            loc: Location parameter.
+        """
+        super().__init__(p=p, chi=chi, psi=psi, loc=loc)
+
+    def _scipy_params(self) -> tuple[t.Any, t.Any, t.Any, t.Any]:
+        """Convert the GIG parameters to SciPy's parameterisation."""
+        if xp.__name__ == "cupy":
+            raise NotImplementedError("GeneralizedInverseGaussian is not supported on GPU.")
+
+        p, chi, psi, loc = self._param_values
+        if bool(np.any(chi <= 0)):
+            raise ValueError("chi must be strictly positive.")
+        if bool(np.any(psi <= 0)):
+            raise ValueError("psi must be strictly positive.")
+        scipy_shape = np.sqrt(chi * psi)
+        scipy_scale = np.sqrt(chi / psi)
+        return p, scipy_shape, scipy_scale, loc
+
+    def _wrap_result(
+        self,
+        result: t.Any,
+        argument: DistributionParameter,
+    ) -> ReturnType:
+        """Preserve stochastic coupling when SciPy returns an array."""
+        candidates = (argument, *self._params.values())
+        stochastic_inputs = [value for value in candidates if isinstance(value, StochasticScalar)]
+        if not stochastic_inputs:
+            return float(result)
+
+        wrapped = StochasticScalar(result)
+        for value in stochastic_inputs:
+            wrapped.coupled_variable_group.merge(value.coupled_variable_group)
+        return wrapped
+
+    @override
+    def cdf(self, x: DistributionParameter) -> ReturnType:
+        """Compute cumulative distribution function."""
+        p, scipy_shape, scipy_scale, loc = self._scipy_params()
+        values = x.values if isinstance(x, StochasticScalar) else x
+        result = geninvgauss.cdf(
+            values,
+            p,
+            scipy_shape,
+            loc=loc,
+            scale=scipy_scale,
+        )
+        return self._wrap_result(result, x)
+
+    @override
+    def invcdf(self, u: DistributionParameter) -> ReturnType:
+        """Compute inverse cumulative distribution function."""
+        p, scipy_shape, scipy_scale, loc = self._scipy_params()
+        values = u.values if isinstance(u, StochasticScalar) else u
+        result = geninvgauss.ppf(
+            values,
+            p,
+            scipy_shape,
+            loc=loc,
+            scale=scipy_scale,
+        )
+        return self._wrap_result(result, u)
+
+    @override
+    def _generate(self, n_sims: int, rng: np.random.Generator) -> StochasticScalar:
+        """Generate random samples using SciPy's GIG sampler."""
+        p, scipy_shape, scipy_scale, loc = self._scipy_params()
+        result = geninvgauss.rvs(
+            p,
+            scipy_shape,
+            loc=loc,
+            scale=scipy_scale,
+            size=n_sims,
+            random_state=rng,
+        )
+        return StochasticScalar(result)
+
+
 class Exponential(DistributionBase):
     r"""Exponential Distribution.
 
@@ -1470,10 +1959,13 @@ AVAILABLE_CONTINUOUS_DISTRIBUTIONS: dict[str, t.Any] = {
     "gamma": Gamma,
     "gev": GEV,
     "gpd": GPD,
+    "generalizedinversegaussian": GeneralizedInverseGaussian,
     "inversegaussian": InverseGaussian,
     "logistic": Logistic,
     "lognormal": LogNormal,
     "loglogistic": LogLogistic,
+    "mbbefd": MBBEFD,
+    "noncentralchisquared": NonCentralChiSquared,
     "normal": Normal,
     "paralogistic": Paralogistic,
     "pareto": Pareto,

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -689,9 +689,9 @@ class MBBEFD(DistributionBase):
     def _validated_params(self) -> tuple[t.Any, t.Any]:
         """Return parameters after checking the admissible region."""
         g, b = self._param_values
-        if bool(np.any(~np.isfinite(g))) or bool(np.any(g < 1)):
+        if bool(xp.any(~xp.isfinite(g))) or bool(xp.any(g < 1)):
             raise ValueError("g must be finite and greater than or equal to 1.")
-        if bool(np.any(~np.isfinite(b))) or bool(np.any(b < 0)):
+        if bool(xp.any(~xp.isfinite(b))) or bool(xp.any(b < 0)):
             raise ValueError("b must be finite and greater than or equal to 0.")
         return g, b
 
@@ -715,57 +715,57 @@ class MBBEFD(DistributionBase):
     def cdf(self, x: DistributionParameter) -> ReturnType:
         """Compute the cumulative distribution function, including the atom at one."""
         g, b = self._validated_params()
-        values = x.values if isinstance(x, StochasticScalar) else x
+        values = to_backend(x.values if isinstance(x, StochasticScalar) else x)
         degenerate = (g == 1) | (b == 0)
-        b_one = np.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
-        bg_one = np.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
+        b_one = xp.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
+        bg_one = xp.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
 
-        safe_g = np.where(degenerate, 2.0, g)
-        safe_b = np.where(degenerate | b_one | bg_one, 2.0, b)
-        limit_b = np.where(degenerate | b_one, 0.5, b)
-        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        safe_g = xp.where(degenerate, 2.0, g)
+        safe_b = xp.where(degenerate | b_one | bg_one, 2.0, b)
+        limit_b = xp.where(degenerate | b_one, 0.5, b)
+        with xp.errstate(divide="ignore", invalid="ignore", over="ignore"):
             main = 1 - (1 - safe_b) * safe_b**values / ((safe_g - 1) * safe_b + (1 - safe_g * safe_b) * safe_b**values)
             b_limit = 1 - 1 / (1 + (g - 1) * values)
             bg_limit = 1 - limit_b**values
 
-        interior = np.where(
+        interior = xp.where(
             degenerate,
             0.0,
-            np.where(b_one, b_limit, np.where(bg_one, bg_limit, main)),
+            xp.where(b_one, b_limit, xp.where(bg_one, bg_limit, main)),
         )
-        result = np.where(values <= 0, 0.0, np.where(values >= 1, 1.0, interior))
+        result = xp.where(values <= 0, 0.0, xp.where(values >= 1, 1.0, interior))
         return self._wrap_result(result, x)
 
     @override
     def invcdf(self, u: DistributionParameter) -> ReturnType:
         """Compute the inverse CDF, returning one across the total-loss atom."""
         g, b = self._validated_params()
-        probabilities = u.values if isinstance(u, StochasticScalar) else u
+        probabilities = to_backend(u.values if isinstance(u, StochasticScalar) else u)
         degenerate = (g == 1) | (b == 0)
-        b_one = np.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
-        bg_one = np.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
+        b_one = xp.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
+        bg_one = xp.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
 
-        safe_g = np.where(degenerate, 2.0, g)
-        safe_b = np.where(degenerate | b_one | bg_one, 2.0, b)
-        limit_b = np.where(degenerate | b_one, 0.5, b)
-        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        safe_g = xp.where(degenerate, 2.0, g)
+        safe_b = xp.where(degenerate | b_one | bg_one, 2.0, b)
+        limit_b = xp.where(degenerate | b_one, 0.5, b)
+        with xp.errstate(divide="ignore", invalid="ignore", over="ignore"):
             main_argument = (safe_g * safe_b - 1) / (safe_g - 1) + ((1 - safe_b) / ((1 - probabilities) * (safe_g - 1)))
-            main = 1 - np.log(main_argument) / np.log(safe_b)
+            main = 1 - xp.log(main_argument) / xp.log(safe_b)
             b_limit = probabilities / ((1 - probabilities) * (safe_g - 1))
-            bg_limit = np.log1p(-probabilities) / np.log(limit_b)
+            bg_limit = xp.log1p(-probabilities) / xp.log(limit_b)
 
-        below_atom = np.where(
+        below_atom = xp.where(
             degenerate,
             1.0,
-            np.where(b_one, b_limit, np.where(bg_one, bg_limit, main)),
+            xp.where(b_one, b_limit, xp.where(bg_one, bg_limit, main)),
         )
-        result = np.where(
+        result = xp.where(
             (probabilities < 0) | (probabilities > 1),
-            np.nan,
-            np.where(
+            xp.nan,
+            xp.where(
                 degenerate | (probabilities >= 1 - 1 / g),
                 1.0,
-                np.where(probabilities == 0, 0.0, below_atom),
+                xp.where(probabilities == 0, 0.0, below_atom),
             ),
         )
         return self._wrap_result(result, u)
@@ -782,26 +782,26 @@ class MBBEFD(DistributionBase):
             Proportion of expected loss below the policy limit.
         """
         g, b = self._validated_params()
-        values = x.values if isinstance(x, StochasticScalar) else x
+        values = to_backend(x.values if isinstance(x, StochasticScalar) else x)
         degenerate = (g == 1) | (b == 0)
-        b_one = np.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
-        bg_one = np.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
+        b_one = xp.isclose(b, 1, rtol=TOLERANCE, atol=TOLERANCE)
+        bg_one = xp.isclose(b * g, 1, rtol=TOLERANCE, atol=TOLERANCE)
 
-        safe_g = np.where(degenerate, 2.0, g)
-        safe_b = np.where(degenerate | b_one | bg_one, 2.0, b)
-        limit_b = np.where(degenerate | b_one, 0.5, b)
-        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        safe_g = xp.where(degenerate, 2.0, g)
+        safe_b = xp.where(degenerate | b_one | bg_one, 2.0, b)
+        limit_b = xp.where(degenerate | b_one, 0.5, b)
+        with xp.errstate(divide="ignore", invalid="ignore", over="ignore"):
             numerator = (safe_g - 1) * safe_b + (1 - safe_g * safe_b) * safe_b**values
-            main = np.log(numerator / (1 - safe_b)) / np.log(safe_g * safe_b)
-            b_limit = np.log1p((safe_g - 1) * values) / np.log(safe_g)
+            main = xp.log(numerator / (1 - safe_b)) / xp.log(safe_g * safe_b)
+            b_limit = xp.log1p((safe_g - 1) * values) / xp.log(safe_g)
             bg_limit = (1 - limit_b**values) / (1 - limit_b)
 
-        interior = np.where(
+        interior = xp.where(
             degenerate,
             values,
-            np.where(b_one, b_limit, np.where(bg_one, bg_limit, main)),
+            xp.where(b_one, b_limit, xp.where(bg_one, bg_limit, main)),
         )
-        result = np.where(values <= 0, 0.0, np.where(values >= 1, 1.0, interior))
+        result = xp.where(values <= 0, 0.0, xp.where(values >= 1, 1.0, interior))
         return self._wrap_result(result, x)
 
 

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -1096,16 +1096,26 @@ class NonCentralChiSquared(DistributionBase):
         """Compute the cumulative distribution function."""
         if xp.__name__ == "cupy":
             raise NotImplementedError("NonCentralChiSquared CDF is not supported on GPU.")
-        df, nonc = self._validated_params()
-        return _special_call(special.chndtr, x, df, nonc)  # type: ignore[return-value]
+        self._validated_params()
+        return _special_call(
+            special.chndtr,
+            x,
+            self._params["df"],
+            self._params["nonc"],
+        )  # type: ignore[return-value]
 
     @override
     def invcdf(self, u: DistributionParameter) -> ReturnType:
         """Compute the inverse cumulative distribution function."""
         if xp.__name__ == "cupy":
             raise NotImplementedError("NonCentralChiSquared inverse CDF is not supported on GPU.")
-        df, nonc = self._validated_params()
-        return _special_call(special.chndtrix, u, df, nonc)  # type: ignore[return-value]
+        self._validated_params()
+        return _special_call(
+            special.chndtrix,
+            u,
+            self._params["df"],
+            self._params["nonc"],
+        )  # type: ignore[return-value]
 
     @override
     def _generate(self, n_sims: int, rng: RandomGenerator) -> StochasticScalar:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -905,7 +905,7 @@ def test_mbbefd_degenerate_case() -> None:
     assert dist.cdf(0.999) == 0.0
     assert dist.cdf(1.0) == 1.0
     assert dist.invcdf(0.0) == 1.0
-    assert np.all(dist.generate(1000) == 1.0)
+    assert np.all(dist.generate(1000).values == 1.0)
     assert dist.exposure_curve(0.4) == pytest.approx(0.4)
 
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -8,6 +8,7 @@ CDF/inverse CDF validation, and simulation accuracy checks.
 import math
 
 import pytest  # pyright: ignore[reportUnknownMemberType] - pytest.approx not fully typed
+import scipy.integrate
 import scipy.special
 from scipy.special import gamma
 
@@ -353,6 +354,82 @@ def test_gamma() -> None:
     assert allclose(np.std(sims), scale * np.sqrt(shape), 1e-3)
 
 
+@pytest.mark.skipif(np.__name__ == "cupy", reason="noncentral chi-squared CDF is CPU-only")
+def test_noncentral_chi_squared_numerical_values() -> None:
+    """Test noncentral chi-squared CDF and quantiles against fixed values."""
+    dist = distributions.NonCentralChiSquared(df=5.0, nonc=2.5)
+    points = StochasticScalar([1.0, 5.0, 10.0, 20.0])
+    probabilities = StochasticScalar([0.01, 0.1, 0.5, 0.9, 0.99])
+
+    assert allclose(
+        dist.cdf(points),
+        StochasticScalar(
+            [
+                0.012707864888969142,
+                0.33342145852973737,
+                0.7551199172247817,
+                0.9848319619365804,
+            ]
+        ),
+        rtol=1e-12,
+    )
+    assert allclose(
+        dist.invcdf(probabilities),
+        StochasticScalar(
+            [
+                0.9020641591262842,
+                2.5664768724950924,
+                6.666110074584612,
+                13.525482664406804,
+                21.33367317975303,
+            ]
+        ),
+        rtol=1e-12,
+    )
+    assert allclose(dist.cdf(dist.invcdf(probabilities)), probabilities, rtol=1e-11)
+    assert dist.cdf(0.0) == 0.0
+    assert dist.invcdf(0.0) == 0.0
+
+
+def test_noncentral_chi_squared_theoretical_moments() -> None:
+    """Test simulated noncentral chi-squared moments against theory."""
+    set_random_seed(12345678910)
+    df = 5.0
+    nonc = 2.5
+    dist = distributions.NonCentralChiSquared(df=df, nonc=nonc)
+    sims = dist.generate(200000)
+
+    assert np.mean(sims) == pytest.approx(df + nonc, rel=5e-3)
+    assert np.var(sims) == pytest.approx(2 * (df + 2 * nonc), rel=1e-2)
+
+
+def test_noncentral_chi_squared_stochastic_parameters() -> None:
+    """Test generation with scenario-varying distribution parameters."""
+    set_random_seed(12345678910)
+    df = StochasticScalar([2.0, 4.0, 6.0])
+    nonc = StochasticScalar([0.0, 1.0, 2.0])
+    sims = distributions.NonCentralChiSquared(df=df, nonc=nonc).generate(3)
+
+    assert sims.n_sims == 3
+    assert bool(np.all(sims.values >= 0))
+    assert sims.coupled_variable_group == df.coupled_variable_group
+    assert sims.coupled_variable_group == nonc.coupled_variable_group
+
+
+def test_noncentral_chi_squared_generator() -> None:
+    """Test construction through the named continuous generator."""
+    generator = distributions.ContinuousDistributionGenerator("noncentralchisquared", [5.0, 2.5])
+
+    assert generator.generate(10).n_sims == 10
+
+
+@pytest.mark.parametrize("df, nonc", [(0.0, 1.0), (-1.0, 1.0), (2.0, -0.1)])
+def test_noncentral_chi_squared_rejects_invalid_parameters(df: float, nonc: float) -> None:
+    """Test validation of degrees of freedom and noncentrality."""
+    with pytest.raises(ValueError):
+        distributions.NonCentralChiSquared(df=df, nonc=nonc).generate(1)
+
+
 def test_log_normal() -> None:
     set_random_seed(12345678910)
     mu = 8
@@ -641,6 +718,219 @@ def test_inversegaussian_cdf_properties() -> None:
     # For inverse Gaussian, CDF(μ) ≈ 0.668 (depends on λ/μ ratio)
     cdf_at_mean = dist.cdf(mu)
     assert 0.5 < cdf_at_mean < 0.8
+
+
+@pytest.mark.skipif(np.__name__ == "cupy", reason="generalized inverse Gaussian is CPU-only")
+def test_generalized_inverse_gaussian() -> None:
+    """Test the generalized inverse Gaussian distribution."""
+    set_random_seed(12345678910)
+    p = 0.75
+    chi = 2.5
+    psi = 1.25
+    loc = 3.0
+    dist = distributions.GeneralizedInverseGaussian(p, chi, psi, loc)
+
+    probabilities = StochasticScalar([0.01, 0.25, 0.5, 0.9, 0.99])
+    quantiles = dist.invcdf(probabilities)
+    assert isinstance(quantiles, StochasticScalar)
+    assert np.allclose(dist.cdf(quantiles), probabilities, rtol=1e-10)
+    assert dist.cdf(loc) == 0.0
+    assert dist.invcdf(0.0) == loc
+    assert np.allclose(
+        dist.cdf(StochasticScalar([3.5, 4.0, 5.0, 10.0])),
+        StochasticScalar(
+            [
+                0.0214939224506453,
+                0.157612365127509,
+                0.491799593366621,
+                0.977313683799349,
+            ]
+        ),
+        rtol=1e-12,
+    )
+    assert np.allclose(
+        dist.invcdf(StochasticScalar([0.01, 0.1, 0.5, 0.9, 0.99])),
+        StochasticScalar(
+            [
+                3.41283685274434,
+                3.82366853423611,
+                5.02868285940702,
+                7.66168386171783,
+                11.2859643689873,
+            ]
+        ),
+        rtol=1e-12,
+    )
+
+    sims = dist.generate(200000)
+    z = math.sqrt(chi * psi)
+    expected_mean = math.sqrt(chi / psi) * scipy.special.kv(p + 1, z) / scipy.special.kv(p, z)
+    expected_second_moment = chi / psi * scipy.special.kv(p + 2, z) / scipy.special.kv(p, z)
+    expected_variance = expected_second_moment - expected_mean**2
+
+    assert np.mean(sims) == pytest.approx(loc + expected_mean, rel=5e-3)
+    assert np.var(sims) == pytest.approx(expected_variance, rel=1e-2)
+
+
+@pytest.mark.skipif(np.__name__ == "cupy", reason="generalized inverse Gaussian is CPU-only")
+def test_generalized_inverse_gaussian_contains_inverse_gaussian() -> None:
+    """Test the inverse Gaussian special case of the GIG distribution."""
+    mu = 4.0
+    lambda_ig = 7.0
+    gig = distributions.GeneralizedInverseGaussian(
+        p=-0.5,
+        chi=lambda_ig,
+        psi=lambda_ig / mu**2,
+    )
+    inverse_gaussian = distributions.InverseGaussian(mu, lambda_ig)
+    points = StochasticScalar([0.5, 1.0, 2.0, 4.0, 8.0, 16.0])
+
+    assert np.allclose(gig.cdf(points), inverse_gaussian.cdf(points), rtol=1e-10)
+
+
+@pytest.mark.skipif(np.__name__ == "cupy", reason="generalized inverse Gaussian is CPU-only")
+def test_generalized_inverse_gaussian_generator() -> None:
+    """Test construction through the named continuous generator."""
+    generator = distributions.ContinuousDistributionGenerator(
+        "generalizedinversegaussian",
+        [-0.5, 7.0, 7.0 / 16.0],
+    )
+
+    assert generator.invcdf(0.5) > 0
+
+
+@pytest.mark.parametrize("chi, psi", [(0.0, 1.0), (-1.0, 1.0), (1.0, 0.0), (1.0, -1.0)])
+@pytest.mark.skipif(np.__name__ == "cupy", reason="generalized inverse Gaussian is CPU-only")
+def test_generalized_inverse_gaussian_rejects_invalid_scales(chi: float, psi: float) -> None:
+    """Test that the GIG scale parameters must be strictly positive."""
+    dist = distributions.GeneralizedInverseGaussian(p=0.5, chi=chi, psi=psi)
+
+    with pytest.raises(ValueError):
+        dist.cdf(1.0)
+
+
+def test_mbbefd() -> None:
+    """Test Bernegger's MBBEFD distribution and total-loss atom."""
+    set_random_seed(12345678910)
+    g = 25.0
+    b = 4.0
+    dist = distributions.MBBEFD(g, b)
+    points = StochasticScalar([0.01, 0.2, 0.5, 0.8, 0.99])
+
+    cdf_values = dist.cdf(points)
+    assert np.all(np.diff(cdf_values) > 0)
+    assert np.allclose(dist.invcdf(cdf_values), points, rtol=1e-10)
+    assert dist.cdf(0.0) == 0.0
+    assert dist.cdf(1.0) == 1.0
+    assert dist.invcdf(1 - 1 / g) == 1.0
+    assert dist.invcdf(0.98) == 1.0
+    assert np.allclose(
+        dist.cdf(StochasticScalar([0.2, 0.5, 0.8, 0.99])),
+        StochasticScalar(
+            [
+                0.885695146977805,
+                0.941176470588235,
+                0.955444536635840,
+                0.959820516901669,
+            ]
+        ),
+        rtol=1e-12,
+    )
+    assert np.allclose(
+        dist.invcdf(StochasticScalar([0.1, 0.25, 0.5, 0.9, 0.95])),
+        StochasticScalar(
+            [
+                0.00250903738331221,
+                0.00755344619510412,
+                0.0229018448065623,
+                0.238219021971494,
+                0.649780140929453,
+            ]
+        ),
+        rtol=1e-12,
+    )
+    assert np.allclose(
+        dist.exposure_curve(StochasticScalar([0.25, 0.5, 0.75])),
+        StochasticScalar(
+            [
+                0.583200958298682,
+                0.765739458521128,
+                0.893865142318307,
+            ]
+        ),
+        rtol=1e-12,
+    )
+
+    sims = dist.generate(200000)
+    expected_mean = (1 - b) * math.log(g * b) / ((1 - g * b) * math.log(b))
+
+    def survival(x: float) -> float:
+        return (1 - b) * b**x / ((g - 1) * b + (1 - g * b) * b**x)
+
+    expected_second_moment = (
+        2
+        * scipy.integrate.quad(
+            lambda x: x * survival(x),
+            0,
+            1,
+            epsabs=1e-12,
+            epsrel=1e-12,
+        )[0]
+    )
+    expected_variance = expected_second_moment - expected_mean**2
+
+    assert expected_mean == pytest.approx(0.100664487723859, rel=1e-12)
+    assert expected_second_moment == pytest.approx(0.0575175543010063, rel=1e-12)
+    assert np.mean(sims) == pytest.approx(expected_mean, rel=5e-3)
+    assert np.mean(sims**2) == pytest.approx(expected_second_moment, rel=1e-2)
+    assert np.var(sims) == pytest.approx(expected_variance, rel=1e-2)
+    assert np.mean(sims == 1) == pytest.approx(1 / g, abs=1e-3)
+
+
+@pytest.mark.parametrize("g, b", [(5.0, 1.0), (4.0, 0.25)])
+def test_mbbefd_limiting_cases(g: float, b: float) -> None:
+    """Test the b=1 and bg=1 limiting cases."""
+    dist = distributions.MBBEFD(g, b)
+    points = StochasticScalar([0.01, 0.2, 0.5, 0.8, 0.99])
+
+    assert np.allclose(dist.invcdf(dist.cdf(points)), points, rtol=1e-10)
+    assert dist.exposure_curve(0.0) == 0.0
+    assert dist.exposure_curve(1.0) == 1.0
+
+
+def test_mbbefd_degenerate_case() -> None:
+    """Test the point-mass boundary of the MBBEFD family."""
+    dist = distributions.MBBEFD(g=1.0, b=2.0)
+
+    assert dist.cdf(0.999) == 0.0
+    assert dist.cdf(1.0) == 1.0
+    assert dist.invcdf(0.0) == 1.0
+    assert np.all(dist.generate(1000) == 1.0)
+    assert dist.exposure_curve(0.4) == pytest.approx(0.4)
+
+
+def test_mbbefd_generator() -> None:
+    """Test construction through the named continuous generator."""
+    generator = distributions.ContinuousDistributionGenerator("mbbefd", [25.0, 4.0])
+
+    assert generator.invcdf(0.5) < 1
+
+
+def test_mbbefd_from_swiss_re_c() -> None:
+    """Test conversion from the standard Swiss Re curve parameter."""
+    dist = distributions.MBBEFD.from_c(3.0)
+
+    assert dist._params["b"] == pytest.approx(3.6692966676)
+    assert dist._params["g"] == pytest.approx(30.569414012)
+
+
+@pytest.mark.parametrize("g, b", [(0.99, 2.0), (2.0, -0.01), (math.inf, 2.0)])
+def test_mbbefd_rejects_invalid_parameters(g: float, b: float) -> None:
+    """Test that MBBEFD parameters outside the admissible region are rejected."""
+    dist = distributions.MBBEFD(g, b)
+
+    with pytest.raises(ValueError):
+        dist.cdf(0.5)
 
 
 def test_hypergeometric() -> None:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -416,6 +416,33 @@ def test_noncentral_chi_squared_stochastic_parameters() -> None:
     assert sims.coupled_variable_group == nonc.coupled_variable_group
 
 
+@pytest.mark.skipif(np.__name__ == "cupy", reason="noncentral chi-squared CDF is CPU-only")
+@pytest.mark.parametrize("method, argument", [("cdf", 5.0), ("invcdf", 0.5)])
+def test_noncentral_chi_squared_stochastic_parameter_coupling(method: str, argument: float) -> None:
+    """Test results are coupled to every stochastic input and parameter."""
+    df = StochasticScalar([2.0, 4.0, 6.0])
+    nonc = StochasticScalar([0.0, 1.0, 2.0])
+    stochastic_argument = StochasticScalar([argument] * 3)
+    dist = distributions.NonCentralChiSquared(df=df, nonc=nonc)
+
+    result = getattr(dist, method)(stochastic_argument)
+
+    assert isinstance(result, StochasticScalar)
+    assert result.coupled_variable_group is stochastic_argument.coupled_variable_group
+    assert result.coupled_variable_group is df.coupled_variable_group
+    assert result.coupled_variable_group is nonc.coupled_variable_group
+
+
+@pytest.mark.skipif(np.__name__ == "cupy", reason="noncentral chi-squared CDF is CPU-only")
+def test_noncentral_chi_squared_stochastic_parameter_with_scalar_argument() -> None:
+    """Test a stochastic parameter produces a coupled stochastic CDF result."""
+    df = StochasticScalar([2.0, 4.0, 6.0])
+    result = distributions.NonCentralChiSquared(df=df, nonc=1.0).cdf(5.0)
+
+    assert isinstance(result, StochasticScalar)
+    assert result.coupled_variable_group is df.coupled_variable_group
+
+
 def test_noncentral_chi_squared_generator() -> None:
     """Test construction through the named continuous generator."""
     generator = distributions.ContinuousDistributionGenerator("noncentralchisquared", [5.0, 2.5])
@@ -773,6 +800,41 @@ def test_generalized_inverse_gaussian() -> None:
 
 
 @pytest.mark.skipif(np.__name__ == "cupy", reason="generalized inverse Gaussian is CPU-only")
+@pytest.mark.parametrize("method, argument", [("cdf", 5.0), ("invcdf", 0.5)])
+def test_generalized_inverse_gaussian_stochastic_parameter_coupling(method: str, argument: float) -> None:
+    """Test GIG results are coupled to every stochastic input and parameter."""
+    p = StochasticScalar([0.5, 0.75, 1.0])
+    chi = StochasticScalar([2.0, 2.5, 3.0])
+    psi = StochasticScalar([1.0, 1.25, 1.5])
+    loc = StochasticScalar([0.0, 0.5, 1.0])
+    stochastic_argument = StochasticScalar([argument] * 3)
+    dist = distributions.GeneralizedInverseGaussian(p=p, chi=chi, psi=psi, loc=loc)
+
+    result = getattr(dist, method)(stochastic_argument)
+
+    assert isinstance(result, StochasticScalar)
+    assert result.coupled_variable_group is stochastic_argument.coupled_variable_group
+    assert result.coupled_variable_group is p.coupled_variable_group
+    assert result.coupled_variable_group is chi.coupled_variable_group
+    assert result.coupled_variable_group is psi.coupled_variable_group
+    assert result.coupled_variable_group is loc.coupled_variable_group
+
+
+@pytest.mark.skipif(np.__name__ == "cupy", reason="generalized inverse Gaussian is CPU-only")
+def test_generalized_inverse_gaussian_stochastic_parameter_generation_coupling() -> None:
+    """Test GIG generation is coupled to every stochastic parameter."""
+    set_random_seed(12345678910)
+    p = StochasticScalar([0.5, 0.75, 1.0])
+    chi = StochasticScalar([2.0, 2.5, 3.0])
+    psi = StochasticScalar([1.0, 1.25, 1.5])
+    result = distributions.GeneralizedInverseGaussian(p=p, chi=chi, psi=psi).generate(3)
+
+    assert result.coupled_variable_group is p.coupled_variable_group
+    assert result.coupled_variable_group is chi.coupled_variable_group
+    assert result.coupled_variable_group is psi.coupled_variable_group
+
+
+@pytest.mark.skipif(np.__name__ == "cupy", reason="generalized inverse Gaussian is CPU-only")
 def test_generalized_inverse_gaussian_contains_inverse_gaussian() -> None:
     """Test the inverse Gaussian special case of the GIG distribution."""
     mu = 4.0
@@ -885,6 +947,36 @@ def test_mbbefd() -> None:
     assert np.mean(sims**2) == pytest.approx(expected_second_moment, rel=1e-2)
     assert np.var(sims) == pytest.approx(expected_variance, rel=1e-2)
     assert np.mean(sims == 1) == pytest.approx(1 / g, abs=1e-3)
+
+
+@pytest.mark.parametrize(
+    "method, argument",
+    [("cdf", 0.5), ("invcdf", 0.5), ("exposure_curve", 0.5)],
+)
+def test_mbbefd_stochastic_parameter_coupling(method: str, argument: float) -> None:
+    """Test MBBEFD results are coupled to every stochastic input and parameter."""
+    g = StochasticScalar([20.0, 25.0, 30.0])
+    b = StochasticScalar([2.0, 3.0, 4.0])
+    stochastic_argument = StochasticScalar([argument] * 3)
+    dist = distributions.MBBEFD(g=g, b=b)
+
+    result = getattr(dist, method)(stochastic_argument)
+
+    assert isinstance(result, StochasticScalar)
+    assert result.coupled_variable_group is stochastic_argument.coupled_variable_group
+    assert result.coupled_variable_group is g.coupled_variable_group
+    assert result.coupled_variable_group is b.coupled_variable_group
+
+
+def test_mbbefd_stochastic_parameter_generation_coupling() -> None:
+    """Test MBBEFD generation is coupled to every stochastic parameter."""
+    set_random_seed(12345678910)
+    g = StochasticScalar([20.0, 25.0, 30.0])
+    b = StochasticScalar([2.0, 3.0, 4.0])
+    result = distributions.MBBEFD(g=g, b=b).generate(3)
+
+    assert result.coupled_variable_group is g.coupled_variable_group
+    assert result.coupled_variable_group is b.coupled_variable_group
 
 
 @pytest.mark.parametrize("g, b", [(5.0, 1.0), (4.0, 0.25)])


### PR DESCRIPTION
## Summary

- add the generalized inverse Gaussian distribution using the `(p, chi, psi)` parameterisation, with CDF, inverse CDF, simulation, validation, stochastic-parameter coupling, and typeset mathematical documentation
- add Bernegger's MBBEFD distribution using the `(g, b)` parameterisation, including its total-loss atom, limiting cases, exposure curve, Swiss Re `from_c` constructor, theoretical-moment tests, and CPU/GPU-compatible numerical paths
- add the noncentral chi-squared distribution using `(df, nonc)`, including CDF, inverse CDF, native CPU/GPU simulation, parameter validation, registration, mathematical documentation, numerical regression tests, inverse-CDF round trips, stochastic-parameter tests, and theoretical-moment simulation tests
- register all three distributions with `ContinuousDistributionGenerator`
- rebase the branch onto the latest `main`

## Validation

- CI tests pass on Python 3.11, 3.12, and 3.13
- static analysis passes, including Ruff formatting/linting and Pyright
- documentation math validation and rendered documentation build pass
- package build passes
- GPU workflow passes: 651 passed, 30 skipped
