### PR TITLE
Accelerate Student's t and copula sampling

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 60
     env:
       PAL_USE_GPU: "1"
+      CUPY_CACHE_DIR: ${{ runner.temp }}/cupy-kernel-cache
 
     steps:
       - uses: actions/checkout@v7
@@ -38,6 +39,35 @@ jobs:
 
       - name: Install dependencies
         run: pip install -e ".[test,gpu]" "cupy-cuda12x[ctk]"
+
+      - name: Determine CuPy kernel-cache compatibility
+        id: cupy-cache-compatibility
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+
+          import cupy
+
+          properties = cupy.cuda.runtime.getDeviceProperties(0)
+          compatibility = (
+              f"py{sys.version_info.major}{sys.version_info.minor}-"
+              f"cupy{cupy.__version__}-"
+              f"cuda{cupy.cuda.runtime.runtimeGetVersion()}-"
+              f"sm{properties['major']}{properties['minor']}"
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"stack={compatibility}", file=output)
+          PY
+
+      - name: Cache CuPy kernels
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CUPY_CACHE_DIR }}
+          key: cupy-kernels-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.cupy-cache-compatibility.outputs.stack }}-${{ hashFiles('src/pal/**/*.py', 'tests/**/*.py', 'docs/**/*.md', 'pyproject.toml') }}
+          restore-keys: |
+            cupy-kernels-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.cupy-cache-compatibility.outputs.stack }}-
 
       - name: Verify GPU acceleration
         run: |

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -24,12 +24,14 @@ jobs:
     timeout-minutes: 60
     env:
       PAL_USE_GPU: "1"
-      CUPY_CACHE_DIR: ${{ runner.temp }}/cupy-kernel-cache
 
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Configure CuPy kernel cache
+        run: echo "CUPY_CACHE_DIR=$RUNNER_TEMP/cupy-kernel-cache" >> "$GITHUB_ENV"
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v7
@@ -64,7 +66,7 @@ jobs:
       - name: Cache CuPy kernels
         uses: actions/cache@v6
         with:
-          path: ${{ env.CUPY_CACHE_DIR }}
+          path: ${{ runner.temp }}/cupy-kernel-cache
           key: cupy-kernels-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.cupy-cache-compatibility.outputs.stack }}-${{ hashFiles('src/pal/**/*.py', 'tests/**/*.py', 'docs/**/*.md', 'pyproject.toml') }}
           restore-keys: |
             cupy-kernels-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.cupy-cache-compatibility.outputs.stack }}-

--- a/src/pal/copulas.py
+++ b/src/pal/copulas.py
@@ -61,11 +61,23 @@ class _BackendGenerator:
         return sample
 
 
-def _backend_rng(generator: t.Any) -> _BackendGenerator:
+def _backend_rng(generator: RandomGenerator | _BackendGenerator) -> RandomGenerator | _BackendGenerator:
     """Return a backend-producing random generator adapter."""
     if isinstance(generator, _BackendGenerator):
         return generator
+    if type(generator).__module__.startswith(np.__name__):
+        return generator
     return _BackendGenerator(generator)
+
+
+def _student_t_cdf(values: t.Any, dof: float) -> t.Any:
+    """Evaluate Student's t CDF without moving backend arrays to the host."""
+    if np.__name__ == "numpy":
+        return special.stdtr(dof, values)
+
+    absolute_values = np.abs(values)
+    tail_probability = special.betainc(dof / 2, 0.5, dof / (dof + absolute_values**2)) / 2
+    return np.where(values >= 0, 1 - tail_probability, tail_probability)
 
 
 class Copula(ABC):
@@ -330,7 +342,7 @@ class StudentsTCopula(EllipticalCopula):
 
     def _transform_to_uniform(self, unnormalised_samples: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
         """Transform t-distributed samples to uniform using CDF."""
-        return np.asarray(scipy.stats.distributions.t(self.dof).cdf(asnumpy(unnormalised_samples)))
+        return _student_t_cdf(unnormalised_samples, self.dof)
 
     def generate(
         self, n_sims: int | None = None, rng: RandomGenerator | None = None
@@ -1693,9 +1705,13 @@ def apply_copula(
 
     # Get sort indices and ranks
     copula_sort_indices = np.argsort(np.array([cs.values for cs in copula_samples]), axis=1, kind="stable")
-    copula_ranks = np.argsort(copula_sort_indices, axis=1)
+    copula_ranks = np.empty_like(copula_sort_indices)
+    copula_ranks[np.arange(len(copula_samples))[:, np.newaxis], copula_sort_indices] = np.arange(
+        copula_sort_indices.shape[1]
+    )
     variable_sort_indices = np.argsort(np.array([var.values for var in variables]), axis=1)
-    first_variable_rank = np.argsort(variable_sort_indices[0])
+    first_variable_rank = np.empty_like(variable_sort_indices[0])
+    first_variable_rank[variable_sort_indices[0]] = np.arange(variable_sort_indices.shape[1])
     copula_ranks = copula_ranks[:, copula_sort_indices[0, first_variable_rank]]
 
     # Apply reordering

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -1593,6 +1593,16 @@ class StudentsT(DistributionBase):
 
         return mu + sigma * sign * x
 
+    @override
+    def _generate(self, n_sims: int, rng: RandomGenerator) -> StochasticScalar:
+        """Generate samples using the active backend's Student's t sampler."""
+        nu, mu, sigma = self._param_values
+        nu = _rng_value(nu, rng)
+        mu = _rng_value(mu, rng)
+        sigma = _rng_value(sigma, rng)
+        samples = rng.standard_t(nu, size=n_sims)
+        return StochasticScalar(mu + sigma * samples)
+
 
 class InverseGaussian(DistributionBase):
     r"""Inverse Gaussian (Wald) Distribution.

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -692,6 +692,21 @@ def test_studentst_heavy_tails() -> None:
     assert t_extreme > normal_extreme
 
 
+def test_studentst_generation_with_stochastic_parameters() -> None:
+    """Generate directly while retaining coupling to stochastic parameters."""
+    n_sims = 4
+    nu = StochasticScalar([3.0, 4.0, 5.0, 6.0])
+    mu = StochasticScalar([0.0, 1.0, 2.0, 3.0])
+    sigma = StochasticScalar([1.0, 1.5, 2.0, 2.5])
+
+    simulations = distributions.StudentsT(nu, mu, sigma).generate(n_sims)
+
+    assert simulations.n_sims == n_sims
+    assert simulations.coupled_variable_group is nu.coupled_variable_group
+    assert simulations.coupled_variable_group is mu.coupled_variable_group
+    assert simulations.coupled_variable_group is sigma.coupled_variable_group
+
+
 def test_inversegaussian() -> None:
     """Test Inverse Gaussian distribution."""
     set_random_seed(12345678910)

--- a/tests/test_gpu_backend.py
+++ b/tests/test_gpu_backend.py
@@ -3,9 +3,10 @@
 import numpy as np
 import pytest
 
-from pal import InverseGaussian, NegBinomial, Normal, set_random_seed
+from pal import InverseGaussian, NegBinomial, Normal, StudentsT, set_random_seed
 from pal._maths import xp
 from pal.config import config
+from pal.copulas import StudentsTCopula
 
 pytestmark = pytest.mark.skipif(xp.__name__ != "cupy", reason="requires the CuPy backend")
 
@@ -30,12 +31,16 @@ def test_generation_and_numpy_dispatch_do_not_transfer_to_host(monkeypatch: pyte
     try:
         set_random_seed(123456789)
         simulations = Normal(100, 15).generate(4096)
+        students_t = StudentsT(5, 100, 15).generate(4096)
+        students_t_copula = StudentsTCopula([[1, 0.5], [0.5, 1]], 5).generate(4096)
         inverse_gaussian = InverseGaussian(2, 3).generate(256)
         negative_binomial = NegBinomial(4, 0.5).generate(256)
         transformed = np.where(simulations > 100, np.exp(simulations / 100), np.square(simulations / 100))
 
         assert type(config.rng).__module__.startswith("cupy")
         assert isinstance(simulations.values, xp.ndarray)
+        assert isinstance(students_t.values, xp.ndarray)
+        assert all(isinstance(margin.values, xp.ndarray) for margin in students_t_copula)
         assert isinstance(inverse_gaussian.values, xp.ndarray)
         assert isinstance(negative_binomial.values, xp.ndarray)
         assert isinstance(transformed.values, xp.ndarray)


### PR DESCRIPTION
## Summary

- sample `StudentsT` directly with the active NumPy/CuPy random generator instead of inverse-CDF sampling
- keep the Student's t copula CDF transform on the active backend, avoiding the full GPU-to-CPU-to-GPU round trip
- bypass the random-generator adapter when the generator already matches the active backend
- replace two rank-sorting passes in `apply_copula` with linear-time rank scatter operations
- extend GPU residency coverage to the Student's t distribution and copula

## CPU benchmarks

Representative local timings:

- `StudentsT(5).generate(100_000)`: 0.0453s → 0.0031s (about 14× faster)
- `apply_copula`, 2 dimensions × 100,000 simulations: 0.0500s → 0.0340s (1.47× faster)
- `apply_copula`, 10 dimensions × 100,000 simulations: 0.2264s → 0.1751s (1.29× faster)
- `apply_copula`, 10 dimensions × 500,000 simulations: 1.5711s → 1.1139s (1.41× faster)

## Validation

- `make static-analysis`
- full local CPU suite: 634 passed, 1 GPU-only test skipped
- hosted GPU suite, including code blocks: 656 passed, 36 skipped in 100.01s
- GPU residency test rejects unexpected host/device transfers through both the Student's t distribution and copula paths
