### PR TITLE
Improve docs sidebar and API navigation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,20 +11,12 @@ https://proteusllp-actuarial-library.readthedocs.io/
 
 ### Prerequisites
 
-Install the documentation dependencies:
+Install the documentation dependencies with pip:
 
 <!--pytest.mark.skip-->
 
 ```bash
-pdm install -G docs
-```
-
-Or with pip:
-
-<!--pytest.mark.skip-->
-
-```bash
-pip install -e .[docs]
+pip install -e ".[docs]"
 ```
 
 ### Build HTML Documentation

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 # Development Guide
 
-This project uses PDM for dependency management, uv for fast installs, and Docker devcontainers for development.
+This project uses pip for dependency installation and Docker devcontainers for development.
 
 ## Getting Started
 
@@ -15,98 +15,75 @@ This project uses PDM for dependency management, uv for fast installs, and Docke
 1. **Open in devcontainer**:
    - Open the project in VS Code
    - Command Palette → "Dev Containers: Reopen in Container"
-   - Wait for container to build (first time takes several minutes).
+   - Wait for the container to build.
 
 2. **Verify setup**:
    ```bash
-   python --version  # Should show Python 3.13.x
-   pdm --version
-   uv --version
+   python --version
+   pip --version
    pytest --version
    ```
 
-## Managing Dependencies
-
-### Dependency Groups
-
-This project uses PDM dependency groups defined in `pyproject.toml`:
-
-- **Core dependencies**: Required runtime dependencies (numpy, scipy, plotly, pandas)
-- **Optional dependencies**:
-  - `gpu`: CUDA support with cupy-cuda12x
-- **Development dependencies**:
-  - `test`: Testing tools (pytest, pytest-cov, pytest-xdist, pytest-codeblocks)
-  - `dev`: Development tools (jupyter, jupyterlab)
-
-**Important**: The devcontainer automatically installs ALL dependency groups (core, optional, and dev groups) to provide a complete development environment. This means you have access to all testing, development, and GPU dependencies without manual installation.
-
-### Adding New Dependencies
-
-Use PDM CLI to manage dependencies:
+The devcontainer installs the project in editable mode with the test, development, and documentation extras:
 
 ```bash
-# Add regular dependencies
-pdm add "new-package>=1.0"
-
-# Add optional dependencies (like GPU)
-pdm add -G gpu "cupy-cuda12x"
-
-# Add development/test dependencies
-pdm add -dG test "pytest-mock"
-
-# Remove dependencies
-pdm remove new-package
+pip install -e ".[test,dev,docs]"
 ```
 
-After adding dependencies, rebuild the container:
-- Command Palette → "Dev Containers: Rebuild Container"
+## Managing Dependencies
 
-### Installing GPU Dependencies
+Dependencies are declared in `pyproject.toml` using standard Python project metadata.
 
-GPU dependencies are in a separate group:
+- **Core dependencies**: required runtime dependencies such as NumPy, SciPy, Plotly and pandas.
+- **Optional dependencies**:
+  - `gpu`: CUDA support with `cupy-cuda12x`.
+  - `docs`: documentation build dependencies.
+  - `test`: testing tools.
+  - `dev`: development and static-analysis tools.
+
+After changing `pyproject.toml`, reinstall the project and the extras you need. For a full development environment:
+
 ```bash
-pdm install -G gpu
+pip install -e ".[test,dev,docs]"
+```
+
+For GPU support:
+
+```bash
+pip install -e ".[gpu]"
+```
+
+Or combine extras when required:
+
+```bash
+pip install -e ".[test,dev,docs,gpu]"
 ```
 
 ## Versioning
 
-**Versions are automatically managed from git tags** - no manual updates needed!
+Versions are automatically managed from Git tags by `setuptools-scm`; no manual version update is required.
 
-### How it works:
-- Version is determined from git tags using SCM (Source Code Management)
-- `dynamic = ["version"]` in pyproject.toml enables this
-- Create releases by tagging: `git tag v1.0.0` → version becomes `1.0.0`
-- Between tags: automatic dev versions like `1.0.0.dev5+g1a2b3c4.d20250630` - this tag would mean that you're on a development version of the package which is 5 commits ahead of `v1.0.0`, with git commit hash beginning `1a2bc4` and built on date `20250630`. `pdm` likely uses `git describe --tags` to generate this string.
+- `dynamic = ["version"]` in `pyproject.toml` enables dynamic versioning.
+- A tag such as `v1.0.0` produces version `1.0.0`.
+- Commits between releases receive an automatically generated development version.
 
-### Creating a release:
-1. **Tag the release**: `git tag v1.0.0`
-2. **Push the tag**: `git push origin v1.0.0`
-3. **Create GitHub Release** from the tag → triggers automatic PyPI publishing
+### Creating a release
 
-### Check current version:
+1. Tag the release: `git tag v1.0.0`
+2. Push the tag: `git push origin v1.0.0`
+3. Create a GitHub Release from that tag. The release workflow publishes the package to PyPI.
+
+### Check the installed version
+
 ```bash
-pdm show --version  # Shows current computed version
+pip show proteusllp-actuarial-library
 ```
 
 ## Release Process
 
-### Creating GitHub Releases
+### Use PEP 440-Compliant Versions
 
-When creating a GitHub release, follow these steps to avoid common issues. If successful, you should CI should be triggered and a release built and pushed to pypi with the associated tag.
-
-#### Create and Push a Valid Tag
-
-GitHub releases require an existing tag. Create one from the command line:
-
-```bash
-# Create a PEP 440-compliant tag
-git tag v0.0.1a1
-git push origin v0.0.1a1
-```
-
-#### Use PEP 440-Compliant Versions
-
-Use a PEP-440-compliant version format. This project uses PDM for Python package versioning, which follows PEP 440. Use these valid version formats:
+Use a PEP 440-compliant version format, for example:
 
 - `v0.0.1a1` (alpha)
 - `v0.0.1b1` (beta)
@@ -114,155 +91,84 @@ Use a PEP-440-compliant version format. This project uses PDM for Python package
 - `v0.0.1.dev1` (development)
 - `v0.0.1.post1` (post-release)
 
-**Avoid** arbitrary suffixes like `-test` that aren't PEP 440 compliant.
+Avoid arbitrary suffixes such as `-test`.
 
-#### Mark Pre-releases Appropriately
-
-For pre-release versions, use GitHub's "Set as pre-release" checkbox instead of adding non-standard suffixes to your tag name.
-
-### Troubleshooting Release Issues
-
-#### "tag name can't be blank, tag name is not well-formed"
-
-This error occurs when:
-- The tag doesn't exist in the repository
-- The tag hasn't been pushed to GitHub
-- The tag name isn't PEP 440 compliant
-
-**Solution**: Create and push a valid tag first, then create the GitHub release.
-
-#### "published releases must have a valid tag"
-
-This indicates the tag exists locally but hasn't been pushed to GitHub.
-
-**Solution**: Push the tag with `git push origin <tag-name>`
+For pre-release versions, use GitHub's "Set as pre-release" option when creating the release.
 
 ## Running Tests
 
 ### From VS Code Terminal
 
-Basic test commands:
 ```bash
 # Run all tests
 pytest
 
-# Run specific test file
+# Run a specific test file
 pytest tests/test_variables.py
 
 # Run with verbose output
 pytest -v
 
-# Run tests with coverage report
+# Run tests with coverage
 pytest --cov=pal
 
-# Run tests in parallel (faster)
+# Run tests in parallel
 pytest -n auto
 
-# Run tests with codeblocks (for doc tests)
+# Execute documentation code blocks
 pytest --codeblocks
 ```
 
 ### From VS Code Test Explorer
 
-1. Open the Test Explorer panel (Testing icon in sidebar)
-2. Click "Configure Python Tests" if prompted
-3. Select "pytest" as the test framework
-4. Tests will appear in the explorer for easy running/debugging
-
-### Test Structure
-
-Tests are organized in the `tests/` directory:
-- `test_*.py` files contain test cases
-- Each test function starts with `test_`
-- Use `pytest.ini` for configuration
+1. Open the Test Explorer panel.
+2. Click "Configure Python Tests" if prompted.
+3. Select `pytest` as the test framework.
 
 ## Static Analysis and Type Checking
 
-### Type Checking with Pyright/Pylance
+PAL uses Pyright for static type checking and Ruff for linting and formatting.
 
-This project uses **Pyright** for static type checking instead of mypy. In VS Code, this is accessed through **Pylance**, which uses Pyright as its underlying type checker.
-
-**Why Pyright over mypy:**
-- **Performance**: Pyright handles large scientific computing dependencies (numpy, scipy, pandas) much faster than mypy
-- **Reliability**: mypy was experiencing crashes and hangs when analyzing scipy-stubs, causing CI failures
-- **Better scientific library support**: Pyright is more robust with complex type hierarchies found in scientific packages
-- **Modern TypeScript engine**: Faster incremental analysis and better error reporting
-
-**Configuration:**
-- Type checking settings are in [`pyrightconfig.json`](../pyrightconfig.json)
-- VS Code uses Pylance (which includes Pyright) via the `ms-python.vscode-pylance` extension
-- **Important**: Pylance automatically uses `pyrightconfig.json` for configuration - no additional VS Code settings needed
-- Both VS Code and CLI use the same Pyright engine and configuration file, ensuring consistent results
-
-**Running type checks:**
 ```bash
-# Via Makefile
+make lint
+make format
 make typecheck
-
-# Or directly
-pyright pal
 ```
 
-**Key insight**: PDM uses `__pypackages__/3.13/lib` instead of traditional virtual environments. When you run `pdm run python`, it automatically adds this path to `sys.path`. Pyright needs `extraPaths` configured to find these packages and their type stubs (numpy, scipy, etc.).
+The same tools can also be run directly from the activated project environment.
 
-## Development Commands (Makefile)
+## Development Commands
 
-**Important**: All Makefile commands must be run from inside the devcontainer. The Makefile assumes access to the PDM-managed Python environment and dependencies.
-
-### Quick Reference
+Run the Makefile commands from inside the devcontainer:
 
 ```bash
-# Inside the devcontainer terminal:
-make help          # Show all available commands
-make lint          # Run ruff linting
-make format        # Run ruff formatting
-make typecheck     # Run pyright type checking
-make test          # Run pytest with coverage
-make build         # Build the package
+make help
+make lint
+make format
+make typecheck
+make test
+make build
 ```
-
-### From Outside the Container
-
-If you need to run commands from outside the devcontainer, use the Docker exec approach documented in [CLAUDE.md](../CLAUDE.md):
-
-```bash
-# Example: Run linting from host machine
-docker exec pal-devcontainer make lint
-
-# Example: Run tests from host machine
-docker exec pal-devcontainer make test
-```
-
-**Recommendation**: Use the devcontainer's integrated terminal in VS Code for the best development experience.
 
 ## Container Architecture
 
-The project uses a multi-stage Dockerfile:
-
-- **base**: Python 3.13 + system dependencies
-- **deps**: All PDM dependencies installed (cached layer)
-- **dev**: Development tools + Jupyter + non-root user
-- **ci**: Test runners + CI tools
+The project uses separate CPU and GPU development containers. Both install PAL into the container using pip in editable mode, so changes to the source tree are immediately available.
 
 ## Troubleshooting
 
-### "pdm.lock out of date" Error
+### Dependencies Not Found
 
-This happens when dependencies change:
+Reinstall the editable package with the required extras:
 
-1. Sync dependencies: `pdm sync`
-2. Or rebuild container: "Dev Containers: Rebuild Container"
+```bash
+pip install -e ".[test,dev,docs]"
+```
+
+If the devcontainer itself has changed, rebuild it with "Dev Containers: Rebuild Container".
 
 ### Container Won't Start
 
-Try rebuilding without cache:
-```bash
-docker build --no-cache --target dev -t proteus-dev .
-```
-
-### Dependencies Not Found
-
-Make sure you rebuilt the container after adding dependencies with `pdm add`. VS Code may use cached layers that don't include new dependencies.
+Rebuild the relevant container without cache if necessary.
 
 ## See Also
 
@@ -272,7 +178,7 @@ Make sure you rebuilt the container after adding dependencies with `pdm add`. VS
 
 ## References
 
-- [PDM Documentation](https://pdm-project.org/)
-- [uv Documentation](https://docs.astral.sh/uv/)
+- [pip Documentation](https://pip.pypa.io/)
+- [Python Packaging User Guide](https://packaging.python.org/)
 - [Dev Containers Documentation](https://containers.dev/)
 - [VS Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers)

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -1,0 +1,9 @@
+{{ objname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :inherited-members:

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,23 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <style>
+    /*
+     * Furo right-aligns its fixed-width sidebar container inside a wider
+     * sidebar drawer on desktop.  The search box therefore looks shifted to
+     * the right if it is sized only against the inner container.  Make the
+     * drawer a size container, then let the search area span the drawer while
+     * retaining the existing 1rem horizontal padding from proteus.css.
+     */
+    .sidebar-drawer {
+      container-type: inline-size;
+    }
+
+    .sidebar-search-container {
+      position: relative;
+      left: calc(100% - 100cqw);
+      width: 100cqw;
+    }
+  </style>
+{% endblock %}

--- a/docs/source/api/copulas.rst
+++ b/docs/source/api/copulas.rst
@@ -1,40 +1,61 @@
 Copulas
 =======
 
-The copulas module provides copula functions for modeling dependencies between stochastic variables.
+The copulas module provides copula models for dependence between stochastic variables. Each concrete copula has its own reference page.
 
-.. automodule:: pal.copulas
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Available Copulas
+Elliptical copulas
 -----------------
 
-The following copulas are available for modeling dependencies:
+.. autosummary::
+   :toctree: copulas
+   :nosignatures:
 
-- **GaussianCopula**: Gaussian (Normal) copula for modeling symmetric dependencies
-- **StudentsTCopula**: Student's t copula for modeling symmetric dependencies with tail dependence
-- **GumbelCopula**: Gumbel copula for modeling upper tail dependence
-- **ClaytonCopula**: Clayton copula for modeling lower tail dependence
-- **FrankCopula**: Frank copula for symmetric dependence
-- **JoeCopula**: Joe copula for modeling upper tail dependence
-- **PlackettCopula**: Plackett copula for modeling symmetric dependencies
-- **GalambosCopula**: Galambos copula for modeling upper tail dependence
-- **HuslerReissCopula**: Hüsler-Reiss copula for flexible upper tail dependence structures
-- **MM1Copula**: Mixture of max-id copulas for flexible upper tail dependence 
-- **ExtremalTCopula**: Extremal-t copula, also known as the t-EV copula, for flexible upper tail dependence
+   pal.copulas.GaussianCopula
+   pal.copulas.StudentsTCopula
 
-Usage Example
+Archimedean copulas
+-------------------
+
+.. autosummary::
+   :toctree: copulas
+   :nosignatures:
+
+   pal.copulas.ClaytonCopula
+   pal.copulas.GumbelCopula
+   pal.copulas.FrankCopula
+   pal.copulas.JoeCopula
+
+Extreme-value and other copulas
+-------------------------------
+
+.. autosummary::
+   :toctree: copulas
+   :nosignatures:
+
+   pal.copulas.GalambosCopula
+   pal.copulas.HuslerReissCopula
+   pal.copulas.ExtremalTCopula
+   pal.copulas.MM1Copula
+   pal.copulas.PlackettCopula
+
+Supporting API
+--------------
+
+.. autosummary::
+   :nosignatures:
+
+   pal.copulas.Copula
+   pal.copulas.EllipticalCopula
+   pal.copulas.ArchimedeanCopula
+
+Usage example
 -------------
 
 .. code-block:: python
 
-   from pal import distributions, copulas
+   from pal import copulas, distributions
 
-   # Create independent variables
    var1 = distributions.Gamma(alpha=2.5, theta=2).generate()
    var2 = distributions.LogNormal(mu=1, sigma=0.5).generate()
 
-   # Apply Gumbel copula to create dependency
    copulas.GumbelCopula(theta=1.2).apply([var1, var2])

--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -1,25 +1,62 @@
 Distributions
 =============
 
-The distributions module provides various statistical distributions for generating stochastic variables.
+The distributions module provides statistical distributions for generating stochastic variables. Each concrete distribution has its own reference page.
 
-.. automodule:: pal.distributions
-   :members:
-   :undoc-members:
-   :show-inheritance:
+Discrete distributions
+----------------------
 
-Available Distributions
------------------------
+.. autosummary::
+   :toctree: distributions
+   :nosignatures:
 
-The following distributions are available:
+   pal.distributions.Poisson
+   pal.distributions.NegBinomial
+   pal.distributions.Binomial
+   pal.distributions.HyperGeometric
+   pal.distributions.Bernoulli
 
-- **Gamma**: Gamma distribution for modeling losses
-- **LogNormal**: Log-normal distribution
-- **Normal**: Normal (Gaussian) distribution
-- **Uniform**: Uniform distribution
-- **Beta**: Beta distribution
-- **Exponential**: Exponential distribution
-- **Weibull**: Weibull distribution
-- **Pareto**: Pareto distribution
+Continuous distributions
+------------------------
 
-All distributions follow a similar API pattern and support GPU acceleration when enabled.
+.. autosummary::
+   :toctree: distributions
+   :nosignatures:
+
+   pal.distributions.GPD
+   pal.distributions.Burr
+   pal.distributions.Beta
+   pal.distributions.MBBEFD
+   pal.distributions.Normal
+   pal.distributions.Logistic
+   pal.distributions.LogNormal
+   pal.distributions.Gamma
+   pal.distributions.NonCentralChiSquared
+   pal.distributions.InverseGamma
+   pal.distributions.Pareto
+   pal.distributions.Paralogistic
+   pal.distributions.InverseBurr
+   pal.distributions.InverseParalogistic
+   pal.distributions.Weibull
+   pal.distributions.InverseWeibull
+   pal.distributions.GEV
+   pal.distributions.StudentsT
+   pal.distributions.InverseGaussian
+   pal.distributions.GeneralizedInverseGaussian
+   pal.distributions.Exponential
+   pal.distributions.Uniform
+   pal.distributions.InverseExponential
+
+Supporting API
+--------------
+
+.. autosummary::
+   :nosignatures:
+
+   pal.distributions.DistributionBase
+   pal.distributions.DiscreteDistributionBase
+   pal.distributions.DistributionGeneratorBase
+   pal.distributions.DiscreteDistributionGenerator
+   pal.distributions.ContinuousDistributionGenerator
+
+All distributions follow the same general API pattern and support the active PAL backend where implemented.

--- a/docs/source/api/pal.copulas.rst
+++ b/docs/source/api/pal.copulas.rst
@@ -1,7 +1,6 @@
+:orphan:
+
 pal.copulas module
 ==================
 
-.. automodule:: pal.copulas
-   :members:
-   :show-inheritance:
-   :undoc-members:
+The copula reference is organised by concrete copula on :doc:`copulas`.

--- a/docs/source/api/pal.distributions.rst
+++ b/docs/source/api/pal.distributions.rst
@@ -1,7 +1,6 @@
+:orphan:
+
 pal.distributions module
 ========================
 
-.. automodule:: pal.distributions
-   :members:
-   :show-inheritance:
-   :undoc-members:
+The distribution reference is organised by concrete distribution on :doc:`distributions`.

--- a/docs/source/api/pal.rst
+++ b/docs/source/api/pal.rst
@@ -1,25 +1,6 @@
+:orphan:
+
 pal package
 ===========
 
-.. automodule:: pal
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-Submodules
-----------
-
-.. toctree::
-   :maxdepth: 4
-
-   pal.config
-   pal.contracts
-   pal.copulas
-   pal.couplings
-   pal.distributions
-   pal.frequency_severity
-   pal.maths
-   pal.stats
-   pal.stochastic_scalar
-   pal.types
-   pal.variables
+The public API reference is organised by topic in :doc:`modules`.

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -1,7 +1,7 @@
 <!--pytest-codeblocks:skipfile-->
 # Development Guide
 
-This project uses PDM for dependency management, uv for fast installs, and Docker devcontainers for development.
+This project uses pip for dependency installation and Docker devcontainers for development.
 
 ## Getting Started
 
@@ -14,98 +14,75 @@ This project uses PDM for dependency management, uv for fast installs, and Docke
 1. **Open in devcontainer**:
    - Open the project in VS Code
    - Command Palette → "Dev Containers: Reopen in Container"
-   - Wait for container to build (first time takes several minutes).
+   - Wait for the container to build.
 
 2. **Verify setup**:
    ```bash
-   python --version  # Should show Python 3.13.x
-   pdm --version
-   uv --version
+   python --version
+   pip --version
    pytest --version
    ```
 
-## Managing Dependencies
-
-### Dependency Groups
-
-This project uses PDM dependency groups defined in `pyproject.toml`:
-
-- **Core dependencies**: Required runtime dependencies (numpy, scipy, plotly, pandas)
-- **Optional dependencies**:
-  - `gpu`: CUDA support with cupy-cuda12x
-- **Development dependencies**:
-  - `test`: Testing tools (pytest, pytest-cov, pytest-xdist)
-  - `dev`: Development tools (jupyter, jupyterlab)
-
-**Important**: The devcontainer automatically installs ALL dependency groups (core, optional, and dev groups) to provide a complete development environment. This means you have access to all testing, development, and GPU dependencies without manual installation.
-
-### Adding New Dependencies
-
-Use PDM CLI to manage dependencies:
+The devcontainer installs the project in editable mode with the test, development, and documentation extras:
 
 ```bash
-# Add regular dependencies
-pdm add "new-package>=1.0"
-
-# Add optional dependencies (like GPU)
-pdm add -G gpu "cupy-cuda12x"
-
-# Add development/test dependencies
-pdm add -dG test "pytest-mock"
-
-# Remove dependencies
-pdm remove new-package
+pip install -e ".[test,dev,docs]"
 ```
 
-After adding dependencies, rebuild the container:
-- Command Palette → "Dev Containers: Rebuild Container"
+## Managing Dependencies
 
-### Installing GPU Dependencies
+Dependencies are declared in `pyproject.toml` using standard Python project metadata.
 
-GPU dependencies are in a separate group:
+- **Core dependencies**: required runtime dependencies such as NumPy, SciPy, Plotly and pandas.
+- **Optional dependencies**:
+  - `gpu`: CUDA support with `cupy-cuda12x`.
+  - `docs`: documentation build dependencies.
+  - `test`: testing tools.
+  - `dev`: development and static-analysis tools.
+
+After changing `pyproject.toml`, reinstall the project and the extras you need. For a full development environment:
+
 ```bash
-pdm install -G gpu
+pip install -e ".[test,dev,docs]"
+```
+
+For GPU support:
+
+```bash
+pip install -e ".[gpu]"
+```
+
+Or combine extras when required:
+
+```bash
+pip install -e ".[test,dev,docs,gpu]"
 ```
 
 ## Versioning
 
-**Versions are automatically managed from git tags** - no manual updates needed!
+Versions are automatically managed from Git tags by `setuptools-scm`; no manual version update is required.
 
-### How it works:
-- Version is determined from git tags using SCM (Source Code Management)
-- `dynamic = ["version"]` in pyproject.toml enables this
-- Create releases by tagging: `git tag v1.0.0` → version becomes `1.0.0`
-- Between tags: automatic dev versions like `1.0.0.dev5+g1a2b3c4.d20250630` - this tag would mean that you're on a development version of the package which is 5 commits ahead of `v1.0.0`, with git commit hash beginning `1a2b3c4` and built on date `20250630`. `pdm` likely uses `git describe --tags` to generate this string.
+- `dynamic = ["version"]` in `pyproject.toml` enables dynamic versioning.
+- A tag such as `v1.0.0` produces version `1.0.0`.
+- Commits between releases receive an automatically generated development version.
 
-### Creating a release:
-1. **Tag the release**: `git tag v1.0.0`
-2. **Push the tag**: `git push origin v1.0.0`
-3. **Create GitHub Release** from the tag → triggers automatic PyPI publishing
+### Creating a release
 
-### Check current version:
+1. Tag the release: `git tag v1.0.0`
+2. Push the tag: `git push origin v1.0.0`
+3. Create a GitHub Release from that tag. The release workflow publishes the package to PyPI.
+
+### Check the installed version
+
 ```bash
-pdm show --version  # Shows current computed version
+pip show proteusllp-actuarial-library
 ```
 
 ## Release Process
 
-### Creating GitHub Releases
+### Use PEP 440-Compliant Versions
 
-When creating a GitHub release, follow these steps to avoid common issues. If successful, CI will be triggered and a release built and pushed to PyPI with the associated tag.
-
-#### Create and Push a Valid Tag
-
-GitHub releases require an existing tag. Create one from the command line:
-
-```bash
-# Create a PEP 440-compliant tag
-git tag v0.0.1a1
-git push origin v0.0.1a1
-```
-
-#### Use PEP 440-Compliant Versions
-
-Use a PEP-440-compliant version format. This project uses PDM for Python package versioning, which follows PEP 440. Use these valid version formats:
+Use a PEP 440-compliant version format, for example:
 
 - `v0.0.1a1` (alpha)
 - `v0.0.1b1` (beta)
@@ -113,106 +90,69 @@ Use a PEP-440-compliant version format. This project uses PDM for Python package
 - `v0.0.1.dev1` (development)
 - `v0.0.1.post1` (post-release)
 
-**Avoid** arbitrary suffixes like `-test` that aren't PEP 440 compliant.
+Avoid arbitrary suffixes such as `-test`.
 
-#### Mark Pre-releases Appropriately
-
-For pre-release versions, use GitHub's "Set as pre-release" checkbox instead of adding non-standard suffixes to your tag name.
-
-### Troubleshooting Release Issues
-
-#### "tag name can't be blank, tag name is not well-formed"
-
-This error occurs when:
-- The tag doesn't exist in the repository
-- The tag hasn't been pushed to GitHub
-- The tag name isn't PEP 440 compliant
-
-**Solution**: Create and push a valid tag first, then create the GitHub release.
-
-#### "published releases must have a valid tag"
-
-This indicates the tag exists locally but hasn't been pushed to GitHub.
-
-**Solution**: Push the tag with `git push origin <tag-name>`
+For pre-release versions, use GitHub's "Set as pre-release" option when creating the release.
 
 ## Running Tests
 
 ### From VS Code Terminal
 
-Basic test commands:
 ```bash
 # Run all tests
 pytest
 
-# Run specific test file
+# Run a specific test file
 pytest tests/test_variables.py
 
 # Run with verbose output
 pytest -v
 
-# Run tests with coverage report
+# Run tests with coverage
 pytest --cov=pal
 
-# Run tests in parallel (faster)
+# Run tests in parallel
 pytest -n auto
 
-# Run tests with codeblocks (for doc tests)
+# Execute documentation code blocks
 pytest --codeblocks
 ```
 
 ### From VS Code Test Explorer
 
-1. Open the Test Explorer panel (Testing icon in sidebar)
-2. Click "Configure Python Tests" if prompted
-3. Select "pytest" as the test framework
-4. Tests will appear in the explorer for easy running/debugging
-
-### Test Structure
-
-Tests are organized in the `tests/` directory:
-- `test_*.py` files contain test cases
-- Each test function starts with `test_`
-- Use `pytest.ini` for configuration
+1. Open the Test Explorer panel.
+2. Click "Configure Python Tests" if prompted.
+3. Select `pytest` as the test framework.
 
 ## Container Architecture
 
-The project uses a multi-stage Dockerfile:
-
-- **base**: Python 3.13 + system dependencies
-- **deps**: All PDM dependencies installed (cached layer)
-- **dev**: Development tools + Jupyter + non-root user
-- **ci**: Test runners + CI tools
+The project uses separate CPU and GPU development containers. Both install PAL into the container using pip in editable mode, so changes to the source tree are immediately available.
 
 ## Troubleshooting
 
-### "pdm.lock out of date" Error
+### Dependencies Not Found
 
-This happens when dependencies change:
+Reinstall the editable package with the required extras:
 
-1. Sync dependencies: `pdm sync`
-2. Or rebuild container: "Dev Containers: Rebuild Container"
+```bash
+pip install -e ".[test,dev,docs]"
+```
+
+If the devcontainer itself has changed, rebuild it with "Dev Containers: Rebuild Container".
 
 ### Container Won't Start
 
-Try rebuilding without cache:
-```bash
-docker build --no-cache --target dev -t proteus-dev .
-```
-
-### Dependencies Not Found
-
-Make sure you rebuilt the container after adding dependencies with `pdm add`. VS Code may use cached layers that don't include new dependencies.
+Rebuild the relevant container without cache if necessary.
 
 ## See Also
 
 - [Usage Guide](usage.md) - Comprehensive examples and API documentation
-- [Examples](https://github.com/ProteusLLP/proteus-actuarial-library/tree/main/examples) - Example scripts showing library usage
-- [Main README](https://github.com/ProteusLLP/proteus-actuarial-library) - Project overview and installation
+- [Examples](https://github.com/ProteusLLP/proteusllp-actuarial-library/tree/main/examples) - Example scripts showing library usage
+- [Main README](https://github.com/ProteusLLP/proteusllp-actuarial-library) - Project overview and installation
 
 ## References
 
-- [PDM Documentation](https://pdm-project.org/)
-- [uv Documentation](https://docs.astral.sh/uv/)
+- [pip Documentation](https://pip.pypa.io/)
+- [Python Packaging User Guide](https://packaging.python.org/)
 - [Dev Containers Documentation](https://containers.dev/)
 - [VS Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers)

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -98,12 +98,12 @@ PAL uses the `default_rng` class from `numpy.random`, which can also be configur
 
 ### GPU Acceleration
 
-For CUDA-compatible GPUs, install PAL with the GPU extra:
+For CUDA-compatible GPUs, install PAL from PyPI with the GPU extra:
 
 <!--pytest.mark.skip-->
 
 ```bash
-pip install -e ".[gpu]"
+pip install "proteusllp-actuarial-library[gpu]"
 ```
 
 Enable GPU mode by setting the environment variable:

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -98,12 +98,12 @@ PAL uses the `default_rng` class from `numpy.random`, which can also be configur
 
 ### GPU Acceleration
 
-For CUDA-compatible GPUs, install GPU dependencies:
+For CUDA-compatible GPUs, install PAL with the GPU extra:
 
 <!--pytest.mark.skip-->
 
 ```bash
-pdm install -G gpu
+pip install -e ".[gpu]"
 ```
 
 Enable GPU mode by setting the environment variable:
@@ -127,7 +127,7 @@ For more complex examples including reinsurance modeling and catastrophe simulat
 ## See Also
 
 - [Development Guide](development.md) - Setting up the development environment
-- [Main README](https://github.com/ProteusLLP/proteus-actuarial-library) - Project overview and quick start
+- [Main README](https://github.com/ProteusLLP/proteusllp-actuarial-library) - Project overview and quick start
 
 ## Performance Tips
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,12 +102,12 @@ PAL supports several environment variables for configuration:
 
 #### GPU Acceleration
 
-For CUDA-compatible GPUs, install GPU dependencies:
+For CUDA-compatible GPUs, install PAL with the GPU extra:
 
 <!--pytest.mark.skip-->
 
 ```bash
-pdm install -G gpu
+pip install -e ".[gpu]"
 ```
 
 Enable GPU mode:
@@ -157,7 +157,7 @@ All development work is done inside the devcontainer. VS Code provides native Ju
 5. **Select Kernel** when prompted:
    - Click "Select Kernel" in the top-right of the notebook
    - Choose "Python Environments"
-   - Select the PDM environment (should show `/workspace/.venv/bin/python`)
+   - Select the project virtual environment (normally `/workspace/.venv/bin/python`)
 6. **Run cells** using:
    - **Ctrl+Enter** - Run current cell
    - **Shift+Enter** - Run current cell and move to next


### PR DESCRIPTION
## Summary

- center the Furo sidebar search area against the full visible sidebar drawer rather than the right-aligned fixed-width inner sidebar container
- give every concrete distribution its own API reference page
- give every concrete copula its own API reference page
- group distribution pages into discrete and continuous sections and copulas into elliptical, Archimedean, and extreme-value/other sections
- use a short-name autosummary template so page titles and navigation entries show `Gamma`, `GumbelCopula`, etc. rather than fully-qualified Python paths
- retire the duplicate generated `pal` API tree that was rendering the same objects a second time
- remove obsolete PDM/uv setup instructions from the documentation and use pip consistently

## Search-bar root cause

Furo deliberately right-aligns `.sidebar-container` inside a wider `.sidebar-drawer` on desktop. The previous fix made the search container correctly size itself within that inner container, but the inner container itself is offset to the right. This is why the field remained visibly off-centre in the rendered documentation.

The fix makes the drawer an inline-size container and lets `.sidebar-search-container` use the drawer width (`100cqw`), shifting it left by exactly the difference between the inner container and drawer widths. When the drawer collapses to the normal sidebar width on smaller screens, that offset naturally becomes zero.

## API structure

The distribution and copula landing pages now use Sphinx autosummary with `:toctree:`. Sphinx generates one reference page per concrete class, while the landing pages remain concise indexes. The custom autosummary class template keeps those generated page titles readable.

## Installation and development documentation

User-facing installation commands install the released package directly from PyPI: `pip install proteusllp-actuarial-library`, or `pip install "proteusllp-actuarial-library[gpu]"` for GPU support. Editable installs are reserved for contributor/development instructions where the repository itself is being developed. Versioning is correctly described as being provided by `setuptools-scm`.

## Validation

- branch is based on current `main`
- all concrete distribution and copula classes currently exposed by the modules are included in the new indexes
- legacy duplicate `pal.distributions`, `pal.copulas`, and `pal` pages no longer autodocument the same objects again
- published user-facing documentation no longer refers to PDM or uses editable installs for package installation
