### PR TITLE
Fix sidebar search vertical centering

### DIFF
--- a/docs/source/_static/css/sidebar-search-fix.css
+++ b/docs/source/_static/css/sidebar-search-fix.css
@@ -1,0 +1,16 @@
+/* Centre Furo's search form against the full visible sidebar drawer.
+
+On wide screens Furo right-aligns a fixed-width .sidebar-container inside a
+wider .sidebar-drawer. The search form is therefore centred within the inner
+container, not within the visible blue drawer. Keep the form's existing width
+and move it left by half of that extra drawer width. When the drawer and inner
+container have the same width (mobile/narrow layouts), this evaluates to zero.
+*/
+
+.sidebar-drawer {
+  container-type: inline-size;
+}
+
+.sidebar-search-container {
+  transform: translateX(calc((100% - 100cqw) * 0.5));
+}

--- a/docs/source/_static/css/sidebar-search-fix.css
+++ b/docs/source/_static/css/sidebar-search-fix.css
@@ -1,16 +1,9 @@
-/* Centre Furo's search form against the full visible sidebar drawer.
+/* Vertically centre Furo's search input within its search-bar area.
 
-On wide screens Furo right-aligns a fixed-width .sidebar-container inside a
-wider .sidebar-drawer. The search form is therefore centred within the inner
-container, not within the visible blue drawer. Keep the form's existing width
-and move it left by half of that extra drawer width. When the drawer and inner
-container have the same width (mobile/narrow layouts), this evaluates to zero.
-*/
-
-.sidebar-drawer {
-  container-type: inline-size;
-}
+The base Proteus stylesheet gives the search container a full 1rem of bottom
+padding and no top padding, so the input sits at the top of the dark search
+region. Split that spacing evenly above and below the input instead. */
 
 .sidebar-search-container {
-  transform: translateX(calc((100% - 100cqw) * 0.5));
+  padding: 0.5rem 1rem;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,7 @@ exclude_patterns = []
 
 html_theme = "furo"
 html_static_path = ["_static"]
-html_css_files = ["css/proteus.css"]
+html_css_files = ["css/proteus.css", "css/sidebar-search-fix.css"]
 html_logo = "_static/logo/proteus-white-horizontal.svg"
 html_favicon = "_static/logo/pal-favicon.svg"
 html_title = "PAL Documentation"


### PR DESCRIPTION
## Summary

- vertically centre the search field within its dark search-bar area
- leave the horizontal positioning unchanged
- keep the existing field width and styling

## Root cause

The search container currently uses `padding: 0 1rem 1rem`, so it has no top padding and a full `1rem` of bottom padding. That places the input at the top of the dark search region rather than vertically centring it.

The fix overrides the container padding to `0.5rem 1rem`, splitting the existing vertical spacing evenly above and below the input without changing the overall height or horizontal geometry.