### PR TITLE
Make sidebar search centering consistent

### DIFF
--- a/docs/source/_static/css/proteus.css
+++ b/docs/source/_static/css/proteus.css
@@ -43,7 +43,7 @@ body {
 
 .sidebar-search-container {
   box-sizing: border-box;
-  padding: 0 1rem 1rem;
+  padding: 0.5rem 1rem;
   width: 100%;
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,7 @@ exclude_patterns = []
 
 html_theme = "furo"
 html_static_path = ["_static"]
-html_css_files = ["css/proteus.css", "css/sidebar-search-fix.css"]
+html_css_files = ["css/proteus.css"]
 html_logo = "_static/logo/proteus-white-horizontal.svg"
 html_favicon = "_static/logo/pal-favicon.svg"
 html_title = "PAL Documentation"


### PR DESCRIPTION
## Summary

- move the vertical search-bar centering rule into the primary `proteus.css` stylesheet
- make the primary rule symmetric (`0.5rem` above and below the input) instead of the old `0` top / `1rem` bottom padding
- stop loading a second search-only stylesheet in newly generated pages
- retain the old static search-fix file in `_static` temporarily so any cached HTML pages that still reference it continue to render correctly

## Root cause

The two screenshots show two different effective CSS versions, not a page-specific layout rule. In the offset screenshot the search input begins at the top of the dark search region and leaves roughly the old 1rem of space below it; in the correctly centred screenshot there is roughly equal space above and below. That matches the pre-#96 and post-#96 rules exactly.

PR #96 introduced the correction through a new second stylesheet. Read the Docs/CDN/browser caching can therefore temporarily serve some cached HTML pages that do not reference that new stylesheet while newer pages do. This makes the layout appear to change from page to page.

This PR makes the corrected spacing part of the stylesheet every page already uses (`proteus.css`) and removes the extra stylesheet from `html_css_files`, leaving a single source of truth going forward. The legacy file is deliberately left in `_static` for now so older cached HTML that references it does not break while caches expire.

## Expected layout

`.sidebar-search-container` uses `padding: 0.5rem 1rem`, giving the input equal vertical spacing at both Furo desktop and compact breakpoints.