### PR TITLE
Add multivariate probability distributions

### DIFF
--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -47,6 +47,23 @@ Continuous distributions
    pal.distributions.Uniform
    pal.distributions.InverseExponential
 
+Multivariate distributions
+--------------------------
+
+Multivariate samples are returned as a :class:`pal.variables.ProteusVariable`
+with one named :class:`pal.stochastic_scalar.StochasticScalar` per component.
+
+.. autosummary::
+   :toctree: distributions
+   :nosignatures:
+
+   pal.distributions.MultivariateNormal
+   pal.distributions.MultivariateStudentsT
+   pal.distributions.Dirichlet
+   pal.distributions.InvertedDirichlet
+   pal.distributions.GeneralizedDirichlet
+   pal.distributions.InvertedGeneralizedDirichlet
+
 Supporting API
 --------------
 
@@ -55,6 +72,7 @@ Supporting API
 
    pal.distributions.DistributionBase
    pal.distributions.DiscreteDistributionBase
+   pal.distributions.MultivariateDistributionBase
    pal.distributions.DistributionGeneratorBase
    pal.distributions.DiscreteDistributionGenerator
    pal.distributions.ContinuousDistributionGenerator

--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -59,10 +59,13 @@ with one named :class:`pal.stochastic_scalar.StochasticScalar` per component.
 
    pal.distributions.MultivariateNormal
    pal.distributions.MultivariateStudentsT
+   pal.distributions.Multinomial
    pal.distributions.Dirichlet
    pal.distributions.InvertedDirichlet
    pal.distributions.GeneralizedDirichlet
    pal.distributions.InvertedGeneralizedDirichlet
+   pal.distributions.Wishart
+   pal.distributions.InverseWishart
 
 Supporting API
 --------------
@@ -73,6 +76,7 @@ Supporting API
    pal.distributions.DistributionBase
    pal.distributions.DiscreteDistributionBase
    pal.distributions.MultivariateDistributionBase
+   pal.distributions.MatrixDistributionBase
    pal.distributions.DistributionGeneratorBase
    pal.distributions.DiscreteDistributionGenerator
    pal.distributions.ContinuousDistributionGenerator

--- a/docs/tutorials/distributions_guide.md
+++ b/docs/tutorials/distributions_guide.md
@@ -88,6 +88,38 @@ validating simulation results.
 | `Binomial` | `n`, `p` | Events out of fixed trials |
 | `HyperGeometric` | `ngood`, `nbad`, `population_size` | Sampling without replacement |
 
+### Multivariate Distributions
+
+| Distribution | Parameters | Typical Use |
+|-------------|------------|-------------|
+| `MultivariateNormal` | `mean`, `covariance` | Correlated symmetric risk factors |
+| `MultivariateStudentsT` | `nu`, `mean`, `scale` | Correlated heavy-tailed risk factors |
+| `Dirichlet` | `alpha` | Random proportions with a fixed total |
+| `InvertedDirichlet` | `alpha` | Positively dependent ratios and positive vectors |
+| `GeneralizedDirichlet` | `alpha`, `beta` | Proportions with a richer covariance structure |
+| `InvertedGeneralizedDirichlet` | `alpha`, `beta` | Positive vectors with a richer covariance structure |
+
+Multivariate samples contain one `StochasticScalar` per named component:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+economic_factors = distributions.MultivariateStudentsT(
+    nu=6,
+    mean=[0.02, 0.04],
+    scale=[[0.0004, 0.0001], [0.0001, 0.0025]],
+    component_names=["inflation", "equity_return"],
+).generate()
+
+economic_factors["inflation"].mean()
+economic_factors["equity_return"].std()
+```
+
+The generalized Dirichlet returns the final unallocated remainder as an
+explicit component, so all generated components sum to one. The inverted
+Dirichlet uses the final `alpha` value as the common denominator parameter and
+therefore returns one fewer component than the number of parameters.
+
 ## Comparing Severity Distributions
 
 The choice of severity distribution significantly affects tail

--- a/docs/tutorials/distributions_guide.md
+++ b/docs/tutorials/distributions_guide.md
@@ -94,10 +94,13 @@ validating simulation results.
 |-------------|------------|-------------|
 | `MultivariateNormal` | `mean`, `covariance` | Correlated symmetric risk factors |
 | `MultivariateStudentsT` | `nu`, `mean`, `scale` | Correlated heavy-tailed risk factors |
+| `Multinomial` | `n`, `p` | Allocate a fixed count across categories |
 | `Dirichlet` | `alpha` | Random proportions with a fixed total |
 | `InvertedDirichlet` | `alpha` | Positively dependent ratios and positive vectors |
 | `GeneralizedDirichlet` | `alpha`, `beta` | Proportions with a richer covariance structure |
 | `InvertedGeneralizedDirichlet` | `alpha`, `beta` | Positive vectors with a richer covariance structure |
+| `Wishart` | `df`, `scale` | Random covariance or precision matrices |
+| `InverseWishart` | `df`, `scale` | Uncertain covariance matrices |
 
 Multivariate samples contain one `StochasticScalar` per named component:
 
@@ -119,6 +122,21 @@ The generalized Dirichlet returns the final unallocated remainder as an
 explicit component, so all generated components sum to one. The inverted
 Dirichlet uses the final `alpha` value as the common denominator parameter and
 therefore returns one fewer component than the number of parameters.
+
+Wishart and inverse Wishart samples use nested named dimensions. The outer
+variable contains matrix rows and each row contains the corresponding columns:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+covariance = distributions.InverseWishart(
+    df=10,
+    scale=[[0.04, 0.01], [0.01, 0.09]],
+    component_names=["property", "casualty"],
+).generate()
+
+covariance["property"]["casualty"].mean()
+```
 
 ## Comparing Severity Distributions
 

--- a/src/pal/__init__.py
+++ b/src/pal/__init__.py
@@ -29,11 +29,15 @@ from .variables import *
 for _distribution_name in (
     "Dirichlet",
     "GeneralizedDirichlet",
+    "InverseWishart",
     "InvertedDirichlet",
     "InvertedGeneralizedDirichlet",
+    "MatrixDistributionBase",
+    "Multinomial",
     "MultivariateDistributionBase",
     "MultivariateNormal",
     "MultivariateStudentsT",
+    "Wishart",
 ):
     setattr(distributions, _distribution_name, globals()[_distribution_name])
 

--- a/src/pal/__init__.py
+++ b/src/pal/__init__.py
@@ -14,9 +14,27 @@ numpy and ndarrays.
 See: http://github.com/ProteusLLP/proteus-actuarial-library
 """
 
+from . import distributions as distributions
 from .config import *
 from .contracts import *
 from .distributions import *
 from .frequency_severity import *
+from .multivariate_distributions import *
 from .stats import *
 from .variables import *
+
+# ``variables`` depends on ``frequency_severity``, which in turn depends on the
+# univariate distributions module. Attach the multivariate API after those modules
+# have initialized to avoid making that established import cycle recursive.
+for _distribution_name in (
+    "Dirichlet",
+    "GeneralizedDirichlet",
+    "InvertedDirichlet",
+    "InvertedGeneralizedDirichlet",
+    "MultivariateDistributionBase",
+    "MultivariateNormal",
+    "MultivariateStudentsT",
+):
+    setattr(distributions, _distribution_name, globals()[_distribution_name])
+
+del _distribution_name

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -10,7 +10,8 @@ be created and passed to another distribution as a parameter.
 Univariate distributions accept and return only primitives (int, float) or
 StochasticScalar. Multivariate distributions return a ProteusVariable containing
 one StochasticScalar per named component, keeping the simulation dimension
-one-dimensional at each leaf.
+one-dimensional at each leaf. Matrix distributions return nested row and column
+ProteusVariable objects with a StochasticScalar at each named matrix entry.
 
 Type Definitions:
 - DistributionParameter: Union[int, float, StochasticScalar]
@@ -37,11 +38,15 @@ from .types import DistributionParameter, RandomGenerator
 if t.TYPE_CHECKING:
     from .multivariate_distributions import Dirichlet as Dirichlet
     from .multivariate_distributions import GeneralizedDirichlet as GeneralizedDirichlet
+    from .multivariate_distributions import InverseWishart as InverseWishart
     from .multivariate_distributions import InvertedDirichlet as InvertedDirichlet
     from .multivariate_distributions import InvertedGeneralizedDirichlet as InvertedGeneralizedDirichlet
+    from .multivariate_distributions import MatrixDistributionBase as MatrixDistributionBase
+    from .multivariate_distributions import Multinomial as Multinomial
     from .multivariate_distributions import MultivariateDistributionBase as MultivariateDistributionBase
     from .multivariate_distributions import MultivariateNormal as MultivariateNormal
     from .multivariate_distributions import MultivariateStudentsT as MultivariateStudentsT
+    from .multivariate_distributions import Wishart as Wishart
 
 TOLERANCE = 1e-10  # Tolerance for numerical comparisons
 # FIXME: Consider replaching with VectorLike from types.py

--- a/src/pal/distributions.py
+++ b/src/pal/distributions.py
@@ -7,11 +7,10 @@ generation and GPU support are managed via configuration settings.
 It's expected that you construct distributions of distributions ie. a distribution can
 be created and passed to another distribution as a parameter.
 
-Note on Type Signatures:
-Distributions accept and return only primitives (int, float) or StochasticScalar.
-The DistributionParameter type alias is Union[int, float, StochasticScalar].
-Internally, scipy.special functions may operate on arrays extracted from
-StochasticScalar.values, but the public API never exposes raw numpy arrays.
+Univariate distributions accept and return only primitives (int, float) or
+StochasticScalar. Multivariate distributions return a ProteusVariable containing
+one StochasticScalar per named component, keeping the simulation dimension
+one-dimensional at each leaf.
 
 Type Definitions:
 - DistributionParameter: Union[int, float, StochasticScalar]
@@ -34,6 +33,15 @@ from ._maths import asnumpy, scalar_or_array, special, to_backend, xp
 from .config import config
 from .stochastic_scalar import StochasticScalar
 from .types import DistributionParameter, RandomGenerator
+
+if t.TYPE_CHECKING:
+    from .multivariate_distributions import Dirichlet as Dirichlet
+    from .multivariate_distributions import GeneralizedDirichlet as GeneralizedDirichlet
+    from .multivariate_distributions import InvertedDirichlet as InvertedDirichlet
+    from .multivariate_distributions import InvertedGeneralizedDirichlet as InvertedGeneralizedDirichlet
+    from .multivariate_distributions import MultivariateDistributionBase as MultivariateDistributionBase
+    from .multivariate_distributions import MultivariateNormal as MultivariateNormal
+    from .multivariate_distributions import MultivariateStudentsT as MultivariateStudentsT
 
 TOLERANCE = 1e-10  # Tolerance for numerical comparisons
 # FIXME: Consider replaching with VectorLike from types.py

--- a/src/pal/multivariate_distributions.py
+++ b/src/pal/multivariate_distributions.py
@@ -647,8 +647,10 @@ class Multinomial(MultivariateDistributionBase):
 
     def _generate_matrix(self, n_sims: int, rng: RandomGenerator) -> t.Any:
         backend = np if _is_numpy_rng(rng) else xp
-        raw_n = self.n.values if isinstance(self.n, StochasticScalar) else self.n
-        n = backend.broadcast_to(_rng_value(raw_n, rng), (n_sims,)).astype(int)
+        if isinstance(self.n, StochasticScalar):
+            n = _rng_value(self.n.values, rng).astype(int)
+        else:
+            n = backend.full(n_sims, self.n, dtype=int)
         probabilities = _parameter_matrix(self.p, n_sims, rng)
         remaining_n = n.copy()
         remaining_probability = backend.ones(n_sims)
@@ -712,8 +714,10 @@ def _bartlett_factor(
 ) -> t.Any:
     """Generate lower-triangular Bartlett factors on the RNG backend."""
     backend = np if _is_numpy_rng(rng) else xp
-    raw_df = df.values if isinstance(df, StochasticScalar) else df
-    df_values = backend.broadcast_to(_rng_value(raw_df, rng), (n_sims,))
+    if isinstance(df, StochasticScalar):
+        df_values = _rng_value(df.values, rng)
+    else:
+        df_values = backend.full(n_sims, df, dtype=float)
     factor = backend.tril(rng.standard_normal(size=(n_sims, dimension, dimension)), k=-1)
     diagonal_df = df_values[:, None] - backend.arange(dimension)[None, :]
     diagonal = backend.sqrt(rng.gamma(diagonal_df / 2, 2.0))

--- a/src/pal/multivariate_distributions.py
+++ b/src/pal/multivariate_distributions.py
@@ -1,9 +1,10 @@
 """Multivariate probability distributions for simulation models.
 
-The distributions in this module return a :class:`ProteusVariable` containing
-one :class:`StochasticScalar` per component. This preserves PAL's convention
-that each stochastic scalar is indexed only by simulation while giving the
-components a named dimension.
+Vector distributions return a :class:`ProteusVariable` containing one
+:class:`StochasticScalar` per component. Matrix distributions return nested
+row and column variables with a stochastic scalar at each entry. This preserves
+PAL's convention that each stochastic scalar is indexed only by simulation
+while giving every distribution dimension a name.
 """
 
 from __future__ import annotations
@@ -23,6 +24,8 @@ from .variables import ProteusVariable
 MultivariateParameter = t.Union[t.Sequence[DistributionParameter], ProteusVariable[t.Any]]
 MultivariateInput = t.Union[npt.ArrayLike, ProteusVariable[t.Any]]
 MultivariateResult = ProteusVariable[StochasticScalar]
+MatrixInput = t.Union[npt.ArrayLike, ProteusVariable[ProteusVariable[t.Any]]]
+MatrixResult = ProteusVariable[ProteusVariable[StochasticScalar]]
 DensityResult = t.Union[float, StochasticScalar]
 
 
@@ -182,6 +185,66 @@ def _density_result(values: t.Any, stochastic_inputs: t.Iterable[DistributionPar
     return wrapped
 
 
+def _validate_degrees_of_freedom(df: DistributionParameter, dimension: int) -> None:
+    """Validate degrees of freedom for a nonsingular matrix distribution."""
+    raw = df.values if isinstance(df, StochasticScalar) else df
+    values = xp.asarray(to_backend(raw), dtype=float)
+    if bool(xp.any(~xp.isfinite(values))) or bool(xp.any(values <= dimension - 1)):
+        raise ValueError(f"df must be finite and greater than {dimension - 1}.")
+
+
+def _matrix_observations(
+    x: MatrixInput,
+    dimension: int,
+) -> tuple[t.Any, list[StochasticScalar]]:
+    """Return matrix observations with simulations in the leading dimension."""
+    stochastic_inputs: list[StochasticScalar] = []
+    if isinstance(x, ProteusVariable):
+        if len(x) != dimension:
+            raise ValueError(f"x must contain {dimension} rows.")
+        matrix_values: list[list[t.Any]] = []
+        raw_values: list[t.Any] = []
+        for row in x:
+            if not isinstance(row, ProteusVariable) or len(row) != dimension:
+                raise ValueError(f"Each row of x must contain {dimension} columns.")
+            values = list(row.values.values())
+            raw_values.extend(values)
+            matrix_values.append(values)
+        stochastic_inputs = [value for value in raw_values if isinstance(value, StochasticScalar)]
+        n_sims = _parameter_n_sims(stochastic_inputs) or 1
+        rows = [
+            xp.stack(
+                [
+                    value.values if isinstance(value, StochasticScalar) else xp.full(n_sims, value, dtype=float)
+                    for value in row
+                ],
+                axis=0,
+            )
+            for row in matrix_values
+        ]
+        return xp.moveaxis(xp.stack(rows, axis=0), -1, 0), stochastic_inputs
+
+    values = xp.asarray(x, dtype=float)
+    if values.ndim == 2 and values.shape == (dimension, dimension):
+        return values[xp.newaxis, :, :], stochastic_inputs
+    if values.ndim == 3 and values.shape[1:] == (dimension, dimension):
+        return values, stochastic_inputs
+    raise ValueError(
+        f"x must have shape ({dimension}, {dimension}), "
+        f"or (n_sims, {dimension}, {dimension})."
+    )
+
+
+def _positive_definite_support(observations: t.Any) -> tuple[t.Any, t.Any]:
+    """Return positive-definite support flags and finite safe observations."""
+    finite = xp.all(xp.isfinite(observations), axis=(1, 2))
+    identity = xp.eye(observations.shape[1], dtype=float)
+    safe = xp.where(finite[:, xp.newaxis, xp.newaxis], observations, identity)
+    symmetric = xp.all(xp.isclose(safe, xp.swapaxes(safe, 1, 2)), axis=(1, 2))
+    positive_definite = xp.linalg.eigvalsh(safe)[:, 0] > 0
+    return finite & symmetric & positive_definite, safe
+
+
 class MultivariateDistributionBase(ABC):
     """Base class for distributions whose samples contain several components."""
 
@@ -267,6 +330,112 @@ class MultivariateDistributionBase(ABC):
         first = result[0]
         for component in result:
             first.coupled_variable_group.merge(component.coupled_variable_group)
+        for parameter in self._parameters:
+            if isinstance(parameter, StochasticScalar):
+                first.coupled_variable_group.merge(parameter.coupled_variable_group)
+        return result
+
+
+class MatrixDistributionBase(ABC):
+    """Base class for distributions whose samples are square matrices."""
+
+    dimension: int
+
+    def __init__(
+        self,
+        dimension: int,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        row_dim_name: str = "row",
+        column_dim_name: str = "column",
+    ) -> None:
+        """Initialize a matrix distribution.
+
+        Args:
+            dimension: Number of rows and columns in each generated matrix.
+            component_names: Optional names used for both matrix axes.
+            row_dim_name: Name of the row dimension.
+            column_dim_name: Name of the column dimension.
+        """
+        self.dimension = dimension
+        self.row_dim_name = row_dim_name
+        self.column_dim_name = column_dim_name
+        if row_dim_name == column_dim_name:
+            raise ValueError("row_dim_name and column_dim_name must be different.")
+        if component_names is None:
+            self.component_names = [f"component_{index + 1}" for index in range(dimension)]
+        else:
+            self.component_names = list(component_names)
+            if len(self.component_names) != dimension:
+                raise ValueError(f"component_names must contain {dimension} names.")
+            if len(set(self.component_names)) != dimension:
+                raise ValueError("component_names must be unique.")
+
+    @property
+    @abstractmethod
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        """Return scalar and stochastic parameters used by the distribution."""
+
+    @abstractmethod
+    def _generate_matrices(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        """Generate samples with shape ``(dimension, dimension, n_sims)``."""
+
+    @abstractmethod
+    def logpdf(self, x: MatrixInput) -> DensityResult:
+        """Compute the matrix-variate log probability density."""
+
+    def pdf(self, x: MatrixInput) -> DensityResult:
+        """Compute the matrix-variate probability density."""
+        result = self.logpdf(x)
+        if isinstance(result, StochasticScalar):
+            return t.cast(StochasticScalar, np.exp(result))
+        return float(np.exp(result))
+
+    def generate(
+        self,
+        n_sims: int | None = None,
+        rng: RandomGenerator | None = None,
+    ) -> MatrixResult:
+        """Generate random positive-definite matrices.
+
+        Args:
+            n_sims: Number of simulations. Uses the configured value when omitted.
+            rng: Random number generator. Uses the configured generator when omitted.
+
+        Returns:
+            A named row-by-column variable with a stochastic scalar at each entry.
+        """
+        if n_sims is None:
+            n_sims = config.n_sims
+        if n_sims < 1:
+            raise ValueError(f"n_sims must be >= 1, got {n_sims}")
+        parameter_n_sims = _parameter_n_sims(self._parameters)
+        if parameter_n_sims is not None and parameter_n_sims != n_sims:
+            raise ValueError(
+                "The number of simulations in stochastic parameters must match the requested number of simulations."
+            )
+        if rng is None:
+            rng = config.rng
+
+        samples = to_backend(self._generate_matrices(n_sims, rng))
+        expected_shape = (self.dimension, self.dimension, n_sims)
+        if samples.shape != expected_shape:
+            raise RuntimeError("A matrix sampler returned an invalid sample shape.")
+        rows = {
+            row_name: ProteusVariable[StochasticScalar](
+                self.column_dim_name,
+                {
+                    column_name: StochasticScalar(samples[row_index, column_index])
+                    for column_index, column_name in enumerate(self.component_names)
+                },
+            )
+            for row_index, row_name in enumerate(self.component_names)
+        }
+        result = ProteusVariable[ProteusVariable[StochasticScalar]](self.row_dim_name, rows)
+        first = result[0][0]
+        for row in result:
+            for entry in row:
+                first.coupled_variable_group.merge(entry.coupled_variable_group)
         for parameter in self._parameters:
             if isinstance(parameter, StochasticScalar):
                 first.coupled_variable_group.merge(parameter.coupled_variable_group)
@@ -416,6 +585,327 @@ class MultivariateStudentsT(MultivariateDistributionBase):
             - 0.5 * (self.dimension * xp.log(nu_values * np.pi) + log_determinant)
             - 0.5 * (nu_values + self.dimension) * xp.log1p(quadratic / nu_values)
         )
+        return _density_result(result, (*stochastic_inputs, *self._parameters))
+
+
+class Multinomial(MultivariateDistributionBase):
+    r"""Multinomial distribution.
+
+    For :math:`n` independent trials assigned to :math:`d` categories with
+    probabilities :math:`p_1,\ldots,p_d`, the probability mass function is
+
+    .. math::
+
+        \Pr(X=x) = \frac{n!}{\prod_{i=1}^d x_i!}
+        \prod_{i=1}^d p_i^{x_i},
+
+    for non-negative integer counts satisfying :math:`\sum_i x_i=n`. Its mean
+    and covariance are
+
+    .. math::
+
+        \operatorname{E}[X]=np, \qquad
+        \operatorname{Cov}(X)=n\left(\operatorname{diag}(p)-pp^\mathsf{T}\right).
+
+    Parameters:
+        n: Non-negative integer number of trials.
+        p: Category probabilities, which must sum to one.
+        component_names: Optional names for the categories.
+        dim_name: Name of the category dimension.
+    """
+
+    def __init__(
+        self,
+        n: DistributionParameter,
+        p: MultivariateParameter,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        dim_name: str = "category",
+    ) -> None:
+        """Initialize a multinomial distribution."""
+        raw_n = n.values if isinstance(n, StochasticScalar) else n
+        backend_n = xp.asarray(to_backend(raw_n), dtype=float)
+        if (
+            bool(xp.any(~xp.isfinite(backend_n)))
+            or bool(xp.any(backend_n < 0))
+            or bool(xp.any(backend_n != xp.floor(backend_n)))
+        ):
+            raise ValueError("n must contain non-negative integers.")
+        self.n = n
+        self.p, parameter_names = _validate_parameter_vector(p, "p", minimum_length=2)
+        probabilities = _active_parameter_matrix(self.p, _parameter_n_sims(self.p) or 1)
+        if bool(xp.any(probabilities < 0)) or bool(xp.any(probabilities > 1)):
+            raise ValueError("p values must lie between zero and one.")
+        if not bool(xp.all(xp.isclose(xp.sum(probabilities, axis=0), 1.0))):
+            raise ValueError("p values must sum to one.")
+        super().__init__(
+            len(self.p),
+            component_names=parameter_names if component_names is None else component_names,
+            dim_name=dim_name,
+        )
+
+    @property
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        return (self.n, *self.p)
+
+    def _generate_matrix(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        backend = np if _is_numpy_rng(rng) else xp
+        raw_n = self.n.values if isinstance(self.n, StochasticScalar) else self.n
+        n = backend.broadcast_to(_rng_value(raw_n, rng), (n_sims,)).astype(int)
+        probabilities = _parameter_matrix(self.p, n_sims, rng)
+        remaining_n = n.copy()
+        remaining_probability = backend.ones(n_sims)
+        samples = backend.zeros((self.dimension, n_sims), dtype=int)
+        for index in range(self.dimension - 1):
+            conditional_probability = backend.where(
+                remaining_probability > 0,
+                probabilities[index] / remaining_probability,
+                0.0,
+            )
+            conditional_probability = backend.clip(conditional_probability, 0.0, 1.0)
+            draw = rng.binomial(remaining_n, conditional_probability)
+            samples[index] = draw
+            remaining_n = remaining_n - draw
+            remaining_probability = remaining_probability - probabilities[index]
+        samples[-1] = remaining_n
+        return samples
+
+    def logpmf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint log probability mass."""
+        observations, stochastic_inputs = _observation_matrix(x, self.dimension)
+        parameter_n_sims = _parameter_n_sims(self._parameters) or 1
+        n_sims = max(observations.shape[1], parameter_n_sims)
+        if observations.shape[1] not in (1, n_sims):
+            raise ValueError("Observations and stochastic parameters must have compatible simulation counts.")
+        observations = xp.broadcast_to(observations, (self.dimension, n_sims))
+        probabilities = _active_parameter_matrix(self.p, n_sims)
+        raw_n = self.n.values if isinstance(self.n, StochasticScalar) else xp.full(n_sims, self.n)
+        n = xp.broadcast_to(raw_n, (n_sims,))
+        valid = (
+            xp.all(observations >= 0, axis=0)
+            & xp.all(observations == xp.floor(observations), axis=0)
+            & xp.isclose(xp.sum(observations, axis=0), n)
+        )
+        result = special.gammaln(n + 1) - xp.sum(special.gammaln(observations + 1), axis=0)
+        result += xp.sum(special.xlogy(observations, probabilities), axis=0)
+        result = xp.where(valid, result, -xp.inf)
+        return _density_result(result, (*stochastic_inputs, *self._parameters))
+
+    def pmf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint probability mass."""
+        result = self.logpmf(x)
+        if isinstance(result, StochasticScalar):
+            return t.cast(StochasticScalar, np.exp(result))
+        return float(np.exp(result))
+
+    def logpdf(self, x: MultivariateInput) -> DensityResult:
+        """Alias for :meth:`logpmf` provided by the common multivariate API."""
+        return self.logpmf(x)
+
+    def pdf(self, x: MultivariateInput) -> DensityResult:
+        """Alias for :meth:`pmf` provided by the common multivariate API."""
+        return self.pmf(x)
+
+
+def _bartlett_factor(
+    df: DistributionParameter,
+    dimension: int,
+    n_sims: int,
+    rng: RandomGenerator,
+) -> t.Any:
+    """Generate lower-triangular Bartlett factors on the RNG backend."""
+    backend = np if _is_numpy_rng(rng) else xp
+    raw_df = df.values if isinstance(df, StochasticScalar) else df
+    df_values = backend.broadcast_to(_rng_value(raw_df, rng), (n_sims,))
+    factor = backend.tril(rng.standard_normal(size=(n_sims, dimension, dimension)), k=-1)
+    diagonal_df = df_values[:, None] - backend.arange(dimension)[None, :]
+    diagonal = backend.sqrt(rng.gamma(diagonal_df / 2, 2.0))
+    indices = backend.arange(dimension)
+    factor[:, indices, indices] = diagonal
+    return factor
+
+
+class Wishart(MatrixDistributionBase):
+    r"""Wishart distribution over positive-definite matrices.
+
+    If :math:`S\sim W_p(\nu,\Sigma)`, its density is
+
+    .. math::
+
+        f(S) = \frac{|S|^{(\nu-p-1)/2}
+        \exp\{-\operatorname{tr}(\Sigma^{-1}S)/2\}}
+        {2^{\nu p/2}|\Sigma|^{\nu/2}\Gamma_p(\nu/2)},
+
+    for positive-definite :math:`S`, where :math:`\nu>p-1` and
+    :math:`\Sigma` is positive definite. The mean is
+    :math:`\operatorname{E}[S]=\nu\Sigma`.
+
+    Parameters:
+        df: Degrees of freedom :math:`\nu`, greater than :math:`p-1`.
+        scale: Positive-definite scale matrix :math:`\Sigma`.
+        component_names: Optional names used for both matrix axes.
+        row_dim_name: Name of the row dimension.
+        column_dim_name: Name of the column dimension.
+
+    References:
+        Eaton, M. L. (1983). Multivariate Statistics: A Vector Space Approach.
+        Wiley.
+    """
+
+    def __init__(
+        self,
+        df: DistributionParameter,
+        scale: npt.ArrayLike,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        row_dim_name: str = "row",
+        column_dim_name: str = "column",
+    ) -> None:
+        """Initialize a Wishart distribution."""
+        scale_values = xp.asarray(scale, dtype=float)
+        if scale_values.ndim != 2 or scale_values.shape[0] != scale_values.shape[1]:
+            raise ValueError("scale must be a square matrix.")
+        dimension = scale_values.shape[0]
+        self.df = df
+        self.scale = scale_values
+        self._chol = _validate_matrix(scale_values, dimension, "scale")
+        _validate_degrees_of_freedom(df, dimension)
+        self._scale_inverse = xp.linalg.solve(scale_values, xp.eye(dimension))
+        self._log_determinant = 2 * xp.sum(xp.log(xp.diag(self._chol)))
+        super().__init__(
+            dimension,
+            component_names=component_names,
+            row_dim_name=row_dim_name,
+            column_dim_name=column_dim_name,
+        )
+
+    @property
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        return (self.df,)
+
+    def _generate_matrices(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        backend = np if _is_numpy_rng(rng) else xp
+        factor = _bartlett_factor(self.df, self.dimension, n_sims, rng)
+        chol = _rng_value(self._chol, rng)
+        transformed = backend.matmul(chol[None, :, :], factor)
+        samples = backend.matmul(transformed, backend.swapaxes(transformed, 1, 2))
+        return backend.moveaxis(samples, 0, -1)
+
+    def logpdf(self, x: MatrixInput) -> DensityResult:
+        """Compute the joint log probability density."""
+        observations, stochastic_inputs = _matrix_observations(x, self.dimension)
+        parameter_n_sims = _parameter_n_sims(self._parameters) or 1
+        n_sims = max(observations.shape[0], parameter_n_sims)
+        if observations.shape[0] not in (1, n_sims):
+            raise ValueError("Observations and stochastic parameters must have compatible simulation counts.")
+        observations = xp.broadcast_to(observations, (n_sims, self.dimension, self.dimension))
+        valid, safe = _positive_definite_support(observations)
+        raw_df = self.df.values if isinstance(self.df, StochasticScalar) else xp.full(n_sims, self.df)
+        df = xp.broadcast_to(raw_df, (n_sims,))
+        _, log_determinant = xp.linalg.slogdet(safe)
+        trace = xp.einsum("ij,sji->s", self._scale_inverse, safe)
+        result = (
+            0.5 * (df - self.dimension - 1) * log_determinant
+            - 0.5 * trace
+            - 0.5 * df * self.dimension * np.log(2)
+            - 0.5 * df * self._log_determinant
+            - special.multigammaln(df / 2, self.dimension)
+        )
+        result = xp.where(valid, result, -xp.inf)
+        return _density_result(result, (*stochastic_inputs, *self._parameters))
+
+
+class InverseWishart(MatrixDistributionBase):
+    r"""Inverse Wishart distribution over positive-definite matrices.
+
+    If :math:`S\sim W_p^{-1}(\nu,\Psi)`, its density is
+
+    .. math::
+
+        f(S) = \frac{|\Psi|^{\nu/2}
+        \exp\{-\operatorname{tr}(\Psi S^{-1})/2\}}
+        {2^{\nu p/2}|S|^{(\nu+p+1)/2}\Gamma_p(\nu/2)},
+
+    for positive-definite :math:`S`. When :math:`\nu>p+1`, its mean is
+
+    .. math::
+
+        \operatorname{E}[S] = \frac{\Psi}{\nu-p-1}.
+
+    Parameters:
+        df: Degrees of freedom :math:`\nu`, greater than :math:`p-1`.
+        scale: Positive-definite scale matrix :math:`\Psi`.
+        component_names: Optional names used for both matrix axes.
+        row_dim_name: Name of the row dimension.
+        column_dim_name: Name of the column dimension.
+
+    References:
+        Axen, S. D. (2023). Efficiently generating inverse-Wishart matrices
+        and their Cholesky factors. arXiv:2310.15884.
+    """
+
+    def __init__(
+        self,
+        df: DistributionParameter,
+        scale: npt.ArrayLike,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        row_dim_name: str = "row",
+        column_dim_name: str = "column",
+    ) -> None:
+        """Initialize an inverse Wishart distribution."""
+        scale_values = xp.asarray(scale, dtype=float)
+        if scale_values.ndim != 2 or scale_values.shape[0] != scale_values.shape[1]:
+            raise ValueError("scale must be a square matrix.")
+        dimension = scale_values.shape[0]
+        self.df = df
+        self.scale = scale_values
+        self._chol = _validate_matrix(scale_values, dimension, "scale")
+        _validate_degrees_of_freedom(df, dimension)
+        self._log_determinant = 2 * xp.sum(xp.log(xp.diag(self._chol)))
+        super().__init__(
+            dimension,
+            component_names=component_names,
+            row_dim_name=row_dim_name,
+            column_dim_name=column_dim_name,
+        )
+
+    @property
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        return (self.df,)
+
+    def _generate_matrices(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        backend = np if _is_numpy_rng(rng) else xp
+        factor = _bartlett_factor(self.df, self.dimension, n_sims, rng)
+        chol = _rng_value(self._chol, rng)
+        right_hand_side = backend.broadcast_to(chol.T, (n_sims, self.dimension, self.dimension))
+        solved = backend.linalg.solve(factor, right_hand_side)
+        samples = backend.matmul(backend.swapaxes(solved, 1, 2), solved)
+        return backend.moveaxis(samples, 0, -1)
+
+    def logpdf(self, x: MatrixInput) -> DensityResult:
+        """Compute the joint log probability density."""
+        observations, stochastic_inputs = _matrix_observations(x, self.dimension)
+        parameter_n_sims = _parameter_n_sims(self._parameters) or 1
+        n_sims = max(observations.shape[0], parameter_n_sims)
+        if observations.shape[0] not in (1, n_sims):
+            raise ValueError("Observations and stochastic parameters must have compatible simulation counts.")
+        observations = xp.broadcast_to(observations, (n_sims, self.dimension, self.dimension))
+        valid, safe = _positive_definite_support(observations)
+        raw_df = self.df.values if isinstance(self.df, StochasticScalar) else xp.full(n_sims, self.df)
+        df = xp.broadcast_to(raw_df, (n_sims,))
+        _, log_determinant = xp.linalg.slogdet(safe)
+        scale = xp.broadcast_to(self.scale, (n_sims, self.dimension, self.dimension))
+        solved = xp.linalg.solve(safe, scale)
+        trace = xp.sum(xp.diagonal(solved, axis1=1, axis2=2), axis=1)
+        result = (
+            0.5 * df * self._log_determinant
+            - 0.5 * (df + self.dimension + 1) * log_determinant
+            - 0.5 * trace
+            - 0.5 * df * self.dimension * np.log(2)
+            - special.multigammaln(df / 2, self.dimension)
+        )
+        result = xp.where(valid, result, -xp.inf)
         return _density_result(result, (*stochastic_inputs, *self._parameters))
 
 
@@ -727,9 +1217,13 @@ class InvertedGeneralizedDirichlet(MultivariateDistributionBase):
 __all__ = [
     "Dirichlet",
     "GeneralizedDirichlet",
+    "InverseWishart",
     "InvertedDirichlet",
     "InvertedGeneralizedDirichlet",
+    "MatrixDistributionBase",
+    "Multinomial",
     "MultivariateDistributionBase",
     "MultivariateNormal",
     "MultivariateStudentsT",
+    "Wishart",
 ]

--- a/src/pal/multivariate_distributions.py
+++ b/src/pal/multivariate_distributions.py
@@ -229,10 +229,7 @@ def _matrix_observations(
         return values[xp.newaxis, :, :], stochastic_inputs
     if values.ndim == 3 and values.shape[1:] == (dimension, dimension):
         return values, stochastic_inputs
-    raise ValueError(
-        f"x must have shape ({dimension}, {dimension}), "
-        f"or (n_sims, {dimension}, {dimension})."
-    )
+    raise ValueError(f"x must have shape ({dimension}, {dimension}), or (n_sims, {dimension}, {dimension}).")
 
 
 def _positive_definite_support(observations: t.Any) -> tuple[t.Any, t.Any]:

--- a/src/pal/multivariate_distributions.py
+++ b/src/pal/multivariate_distributions.py
@@ -472,7 +472,7 @@ class Dirichlet(MultivariateDistributionBase):
         observations = xp.broadcast_to(observations, (self.dimension, n_sims))
         alpha = _active_parameter_matrix(self.alpha, n_sims)
         valid = xp.all(observations > 0, axis=0) & xp.isclose(xp.sum(observations, axis=0), 1.0)
-        with xp.errstate(divide="ignore", invalid="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore"):
             result = special.gammaln(xp.sum(alpha, axis=0)) - xp.sum(special.gammaln(alpha), axis=0)
             result += xp.sum((alpha - 1) * xp.log(observations), axis=0)
         result = xp.where(valid, result, -xp.inf)
@@ -539,7 +539,7 @@ class InvertedDirichlet(MultivariateDistributionBase):
         observations = xp.broadcast_to(observations, (self.dimension, n_sims))
         alpha = _active_parameter_matrix(self.alpha, n_sims)
         valid = xp.all(observations > 0, axis=0)
-        with xp.errstate(divide="ignore", invalid="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore"):
             result = special.gammaln(xp.sum(alpha, axis=0)) - xp.sum(special.gammaln(alpha), axis=0)
             result += xp.sum((alpha[:-1] - 1) * xp.log(observations), axis=0)
             result -= xp.sum(alpha, axis=0) * xp.log1p(xp.sum(observations, axis=0))
@@ -620,7 +620,7 @@ class GeneralizedDirichlet(MultivariateDistributionBase):
         valid = xp.all(observations > 0, axis=0) & xp.isclose(xp.sum(observations, axis=0), 1.0)
         remainder = xp.ones(n_sims)
         result = xp.zeros(n_sims)
-        with xp.errstate(divide="ignore", invalid="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore"):
             for index in range(len(self.alpha)):
                 proportion = observations[index] / remainder
                 result += (alpha[index] - 1) * xp.log(proportion)
@@ -713,7 +713,7 @@ class InvertedGeneralizedDirichlet(MultivariateDistributionBase):
         valid = xp.all(observations > 0, axis=0)
         cumulative = xp.ones(n_sims)
         result = xp.zeros(n_sims)
-        with xp.errstate(divide="ignore", invalid="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore"):
             for index in range(self.dimension):
                 ratio = observations[index] / cumulative
                 result += (alpha[index] - 1) * xp.log(ratio)

--- a/src/pal/multivariate_distributions.py
+++ b/src/pal/multivariate_distributions.py
@@ -1,0 +1,730 @@
+"""Multivariate probability distributions for simulation models.
+
+The distributions in this module return a :class:`ProteusVariable` containing
+one :class:`StochasticScalar` per component. This preserves PAL's convention
+that each stochastic scalar is indexed only by simulation while giving the
+components a named dimension.
+"""
+
+from __future__ import annotations
+
+import typing as t
+from abc import ABC, abstractmethod
+
+import numpy as np
+import numpy.typing as npt
+
+from ._maths import asnumpy, special, to_backend, xp
+from .config import config
+from .stochastic_scalar import StochasticScalar
+from .types import DistributionParameter, RandomGenerator
+from .variables import ProteusVariable
+
+MultivariateParameter = t.Union[t.Sequence[DistributionParameter], ProteusVariable[t.Any]]
+MultivariateInput = t.Union[npt.ArrayLike, ProteusVariable[t.Any]]
+MultivariateResult = ProteusVariable[StochasticScalar]
+DensityResult = t.Union[float, StochasticScalar]
+
+
+def _is_numpy_rng(rng: RandomGenerator) -> bool:
+    """Return whether a generator produces NumPy arrays."""
+    return type(rng).__module__.startswith("numpy")
+
+
+def _rng_value(value: t.Any, rng: RandomGenerator) -> t.Any:
+    """Place a value on the array backend used by the supplied generator."""
+    if _is_numpy_rng(rng):
+        return asnumpy(value) if isinstance(value, xp.ndarray) else value
+    return to_backend(value)
+
+
+def _sequence_values(parameter: MultivariateParameter) -> tuple[list[DistributionParameter], list[str] | None]:
+    """Return the values and optional names from a vector parameter."""
+    if isinstance(parameter, ProteusVariable):
+        return list(parameter.values.values()), list(parameter.values)
+    values = list(parameter)
+    return values, None
+
+
+def _validate_parameter_vector(
+    parameter: MultivariateParameter,
+    name: str,
+    *,
+    minimum_length: int = 1,
+) -> tuple[list[DistributionParameter], list[str] | None]:
+    """Validate and unpack a vector of scalar or stochastic parameters."""
+    values, names = _sequence_values(parameter)
+    if len(values) < minimum_length:
+        raise ValueError(f"{name} must contain at least {minimum_length} value(s).")
+    for value in values:
+        raw = value.values if isinstance(value, StochasticScalar) else value
+        if bool(xp.any(~xp.isfinite(to_backend(raw)))):
+            raise ValueError(f"{name} values must be finite.")
+    return values, names
+
+
+def _validate_positive_parameter_vector(
+    parameter: MultivariateParameter,
+    name: str,
+    *,
+    minimum_length: int = 1,
+) -> tuple[list[DistributionParameter], list[str] | None]:
+    """Validate and unpack a strictly positive parameter vector."""
+    values, names = _validate_parameter_vector(parameter, name, minimum_length=minimum_length)
+    for value in values:
+        raw = value.values if isinstance(value, StochasticScalar) else value
+        if bool(xp.any(to_backend(raw) <= 0)):
+            raise ValueError(f"{name} values must be positive.")
+    return values, names
+
+
+def _parameter_n_sims(parameters: t.Iterable[DistributionParameter]) -> int | None:
+    """Return the common simulation count of stochastic parameters."""
+    result: int | None = None
+    for parameter in parameters:
+        if not isinstance(parameter, StochasticScalar):
+            continue
+        if result is None:
+            result = parameter.n_sims
+        elif parameter.n_sims != result:
+            raise ValueError("Stochastic parameters must have the same number of simulations.")
+    return result
+
+
+def _parameter_matrix(
+    parameters: t.Sequence[DistributionParameter],
+    n_sims: int,
+    rng: RandomGenerator,
+) -> t.Any:
+    """Broadcast vector parameters across simulations on the generator backend."""
+    rows: list[t.Any] = []
+    for parameter in parameters:
+        if isinstance(parameter, StochasticScalar):
+            if parameter.n_sims != n_sims:
+                raise ValueError(
+                    "The number of simulations in each stochastic parameter must "
+                    "match the requested number of simulations."
+                )
+            rows.append(_rng_value(parameter.values, rng))
+        else:
+            backend = np if _is_numpy_rng(rng) else xp
+            rows.append(backend.full(n_sims, parameter, dtype=float))
+    backend = np if _is_numpy_rng(rng) else xp
+    return backend.stack(rows, axis=0)
+
+
+def _active_parameter_matrix(parameters: t.Sequence[DistributionParameter], n_sims: int) -> t.Any:
+    """Broadcast vector parameters across simulations on PAL's active backend."""
+    rows: list[t.Any] = []
+    for parameter in parameters:
+        if isinstance(parameter, StochasticScalar):
+            if parameter.n_sims != n_sims:
+                raise ValueError("Stochastic parameters and observations must have the same number of simulations.")
+            rows.append(parameter.values)
+        else:
+            rows.append(xp.full(n_sims, parameter, dtype=float))
+    return xp.stack(rows, axis=0)
+
+
+def _validate_matrix(matrix: npt.ArrayLike, dimension: int, name: str) -> t.Any:
+    """Return the Cholesky factor of a symmetric positive-definite matrix."""
+    values = xp.asarray(matrix, dtype=float)
+    if values.ndim != 2 or values.shape != (dimension, dimension):
+        raise ValueError(f"{name} must be a {dimension} by {dimension} matrix.")
+    if bool(xp.any(~xp.isfinite(values))):
+        raise ValueError(f"{name} values must be finite.")
+    if not bool(xp.allclose(values, values.T)):
+        raise ValueError(f"{name} must be symmetric.")
+    try:
+        return xp.linalg.cholesky(values)
+    except xp.linalg.LinAlgError as error:
+        raise ValueError(f"{name} must be positive definite.") from error
+
+
+def _observation_matrix(x: MultivariateInput, dimension: int) -> tuple[t.Any, list[StochasticScalar]]:
+    """Return observations with components in rows and simulations in columns."""
+    stochastic_inputs: list[StochasticScalar] = []
+    if isinstance(x, ProteusVariable):
+        if len(x) != dimension:
+            raise ValueError(f"x must contain {dimension} components.")
+        values = list(x.values.values())
+        stochastic_inputs = [value for value in values if isinstance(value, StochasticScalar)]
+        n_sims = _parameter_n_sims(stochastic_inputs) or 1
+        rows = [
+            value.values if isinstance(value, StochasticScalar) else xp.full(n_sims, value, dtype=float)
+            for value in values
+        ]
+        return xp.stack(rows, axis=0), stochastic_inputs
+
+    values = xp.asarray(x, dtype=float)
+    if values.ndim == 1:
+        if values.shape[0] != dimension:
+            raise ValueError(f"x must contain {dimension} components.")
+        return values[:, xp.newaxis], stochastic_inputs
+    if values.ndim == 2 and values.shape[0] == dimension:
+        return values, stochastic_inputs
+    raise ValueError(f"x must have shape ({dimension},) or ({dimension}, n_sims).")
+
+
+def _density_result(values: t.Any, stochastic_inputs: t.Iterable[DistributionParameter]) -> DensityResult:
+    """Wrap simulation-varying density values and preserve their coupling."""
+    inputs = [value for value in stochastic_inputs if isinstance(value, StochasticScalar)]
+    result = xp.asarray(values)
+    if result.size == 1 and not inputs:
+        return float(result.item())
+    wrapped = StochasticScalar(result.reshape(-1))
+    for value in inputs:
+        wrapped.coupled_variable_group.merge(value.coupled_variable_group)
+    return wrapped
+
+
+class MultivariateDistributionBase(ABC):
+    """Base class for distributions whose samples contain several components."""
+
+    dimension: int
+
+    def __init__(
+        self,
+        dimension: int,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        dim_name: str = "component",
+    ) -> None:
+        """Initialize a multivariate distribution.
+
+        Args:
+            dimension: Number of components in each generated sample.
+            component_names: Optional names for the components.
+            dim_name: Name of the component dimension.
+        """
+        self.dimension = dimension
+        self.dim_name = dim_name
+        if component_names is None:
+            self.component_names = [f"component_{index + 1}" for index in range(dimension)]
+        else:
+            self.component_names = list(component_names)
+            if len(self.component_names) != dimension:
+                raise ValueError(f"component_names must contain {dimension} names.")
+            if len(set(self.component_names)) != dimension:
+                raise ValueError("component_names must be unique.")
+
+    @property
+    @abstractmethod
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        """Return scalar and stochastic parameters used by the distribution."""
+
+    @abstractmethod
+    def _generate_matrix(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        """Generate samples with components in rows and simulations in columns."""
+
+    @abstractmethod
+    def logpdf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint log probability density."""
+
+    def pdf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint probability density."""
+        result = self.logpdf(x)
+        if isinstance(result, StochasticScalar):
+            return t.cast(StochasticScalar, np.exp(result))
+        return float(np.exp(result))
+
+    def generate(
+        self,
+        n_sims: int | None = None,
+        rng: RandomGenerator | None = None,
+    ) -> MultivariateResult:
+        """Generate random samples from the distribution.
+
+        Args:
+            n_sims: Number of simulations. Uses the configured value when omitted.
+            rng: Random number generator. Uses the configured generator when omitted.
+
+        Returns:
+            A named variable containing one stochastic scalar per component.
+        """
+        if n_sims is None:
+            n_sims = config.n_sims
+        if n_sims < 1:
+            raise ValueError(f"n_sims must be >= 1, got {n_sims}")
+        parameter_n_sims = _parameter_n_sims(self._parameters)
+        if parameter_n_sims is not None and parameter_n_sims != n_sims:
+            raise ValueError(
+                "The number of simulations in stochastic parameters must match the requested number of simulations."
+            )
+        if rng is None:
+            rng = config.rng
+
+        samples = self._generate_matrix(n_sims, rng)
+        active_samples = to_backend(samples)
+        if active_samples.shape != (self.dimension, n_sims):
+            raise RuntimeError("A multivariate sampler returned an invalid sample shape.")
+        components = {name: StochasticScalar(active_samples[index]) for index, name in enumerate(self.component_names)}
+        result = ProteusVariable[StochasticScalar](self.dim_name, components)
+        first = result[0]
+        for component in result:
+            first.coupled_variable_group.merge(component.coupled_variable_group)
+        for parameter in self._parameters:
+            if isinstance(parameter, StochasticScalar):
+                first.coupled_variable_group.merge(parameter.coupled_variable_group)
+        return result
+
+
+class MultivariateNormal(MultivariateDistributionBase):
+    r"""Multivariate normal distribution.
+
+    For a :math:`d`-dimensional random vector :math:`X`, the density is
+
+    .. math::
+
+        f(x) = \frac{\exp\left(-\tfrac12(x-\mu)^\mathsf{T}
+        \Sigma^{-1}(x-\mu)\right)}
+        {(2\pi)^{d/2}|\Sigma|^{1/2}},
+
+    where :math:`\mu` is the mean vector and :math:`\Sigma` is a symmetric
+    positive-definite covariance matrix.
+
+    Parameters:
+        mean: Mean of each component.
+        covariance: Covariance matrix :math:`\Sigma`.
+        component_names: Optional names for the components.
+        dim_name: Name of the component dimension.
+    """
+
+    def __init__(
+        self,
+        mean: MultivariateParameter,
+        covariance: npt.ArrayLike,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        dim_name: str = "component",
+    ) -> None:
+        """Initialize a multivariate normal distribution."""
+        self.mean, parameter_names = _validate_parameter_vector(mean, "mean")
+        super().__init__(
+            len(self.mean),
+            component_names=parameter_names if component_names is None else component_names,
+            dim_name=dim_name,
+        )
+        self._chol = _validate_matrix(covariance, self.dimension, "covariance")
+
+    @property
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        return tuple(self.mean)
+
+    def _generate_matrix(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        mean = _parameter_matrix(self.mean, n_sims, rng)
+        chol = _rng_value(self._chol, rng)
+        normal = rng.standard_normal(size=(self.dimension, n_sims))
+        return mean + chol @ normal
+
+    def logpdf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint log probability density."""
+        observations, stochastic_inputs = _observation_matrix(x, self.dimension)
+        n_sims = max(observations.shape[1], _parameter_n_sims(self.mean) or 1)
+        if observations.shape[1] not in (1, n_sims):
+            raise ValueError("Observations and stochastic parameters must have compatible simulation counts.")
+        observations = xp.broadcast_to(observations, (self.dimension, n_sims))
+        mean = _active_parameter_matrix(self.mean, n_sims)
+        centred = observations - mean
+        solved = xp.linalg.solve(self._chol, centred)
+        quadratic = xp.sum(solved**2, axis=0)
+        log_determinant = 2 * xp.sum(xp.log(xp.diag(self._chol)))
+        result = -0.5 * (self.dimension * np.log(2 * np.pi) + log_determinant + quadratic)
+        return _density_result(result, (*stochastic_inputs, *self._parameters))
+
+
+class MultivariateStudentsT(MultivariateDistributionBase):
+    r"""Multivariate Student's t distribution.
+
+    The density of a :math:`d`-dimensional random vector is
+
+    .. math::
+
+        f(x) = \frac{\Gamma((\nu+d)/2)}
+        {\Gamma(\nu/2)(\nu\pi)^{d/2}|\Sigma|^{1/2}}
+        \left(1+\frac{(x-\mu)^\mathsf{T}\Sigma^{-1}(x-\mu)}{\nu}
+        \right)^{-(\nu+d)/2},
+
+    where :math:`\nu>0` is the degrees of freedom and :math:`\Sigma` is the
+    scale matrix. When :math:`\nu>2`, the covariance matrix is
+    :math:`\nu\Sigma/(\nu-2)`.
+
+    Parameters:
+        nu: Degrees of freedom :math:`\nu`.
+        mean: Location of each component.
+        scale: Symmetric positive-definite scale matrix :math:`\Sigma`.
+        component_names: Optional names for the components.
+        dim_name: Name of the component dimension.
+    """
+
+    def __init__(
+        self,
+        nu: DistributionParameter,
+        mean: MultivariateParameter,
+        scale: npt.ArrayLike,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        dim_name: str = "component",
+    ) -> None:
+        """Initialize a multivariate Student's t distribution."""
+        raw_nu = nu.values if isinstance(nu, StochasticScalar) else nu
+        if bool(xp.any(~xp.isfinite(to_backend(raw_nu)))) or bool(xp.any(to_backend(raw_nu) <= 0)):
+            raise ValueError("nu must be finite and positive.")
+        self.nu = nu
+        self.mean, parameter_names = _validate_parameter_vector(mean, "mean")
+        super().__init__(
+            len(self.mean),
+            component_names=parameter_names if component_names is None else component_names,
+            dim_name=dim_name,
+        )
+        self._chol = _validate_matrix(scale, self.dimension, "scale")
+
+    @property
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        return (self.nu, *self.mean)
+
+    def _generate_matrix(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        mean = _parameter_matrix(self.mean, n_sims, rng)
+        nu = _rng_value(self.nu.values if isinstance(self.nu, StochasticScalar) else self.nu, rng)
+        chol = _rng_value(self._chol, rng)
+        normal = chol @ rng.standard_normal(size=(self.dimension, n_sims))
+        chi_scale = rng.gamma(nu / 2, 2 / nu, size=n_sims)
+        return mean + normal / chi_scale[None, :] ** 0.5
+
+    def logpdf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint log probability density."""
+        observations, stochastic_inputs = _observation_matrix(x, self.dimension)
+        parameter_n_sims = _parameter_n_sims(self._parameters) or 1
+        n_sims = max(observations.shape[1], parameter_n_sims)
+        if observations.shape[1] not in (1, n_sims):
+            raise ValueError("Observations and stochastic parameters must have compatible simulation counts.")
+        observations = xp.broadcast_to(observations, (self.dimension, n_sims))
+        mean = _active_parameter_matrix(self.mean, n_sims)
+        nu_values = self.nu.values if isinstance(self.nu, StochasticScalar) else xp.full(n_sims, self.nu)
+        centred = observations - mean
+        solved = xp.linalg.solve(self._chol, centred)
+        quadratic = xp.sum(solved**2, axis=0)
+        log_determinant = 2 * xp.sum(xp.log(xp.diag(self._chol)))
+        result = (
+            special.gammaln((nu_values + self.dimension) / 2)
+            - special.gammaln(nu_values / 2)
+            - 0.5 * (self.dimension * xp.log(nu_values * np.pi) + log_determinant)
+            - 0.5 * (nu_values + self.dimension) * xp.log1p(quadratic / nu_values)
+        )
+        return _density_result(result, (*stochastic_inputs, *self._parameters))
+
+
+class Dirichlet(MultivariateDistributionBase):
+    r"""Dirichlet distribution on the probability simplex.
+
+    Its density is
+
+    .. math::
+
+        f(x_1,\ldots,x_d) = \frac{\Gamma(\alpha_0)}
+        {\prod_{i=1}^d\Gamma(\alpha_i)}
+        \prod_{i=1}^d x_i^{\alpha_i-1},
+        \qquad \alpha_0=\sum_{i=1}^d\alpha_i,
+
+    for positive components satisfying :math:`\sum_i x_i=1`.
+
+    Parameters:
+        alpha: Positive concentration parameter for each component.
+        component_names: Optional names for the components.
+        dim_name: Name of the component dimension.
+    """
+
+    def __init__(
+        self,
+        alpha: MultivariateParameter,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        dim_name: str = "component",
+    ) -> None:
+        """Initialize a Dirichlet distribution."""
+        self.alpha, parameter_names = _validate_positive_parameter_vector(alpha, "alpha", minimum_length=2)
+        super().__init__(
+            len(self.alpha),
+            component_names=parameter_names if component_names is None else component_names,
+            dim_name=dim_name,
+        )
+
+    @property
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        return tuple(self.alpha)
+
+    def _generate_matrix(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        alpha = _parameter_matrix(self.alpha, n_sims, rng)
+        gamma = rng.gamma(alpha, 1.0)
+        return gamma / gamma.sum(axis=0, keepdims=True)
+
+    def logpdf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint log probability density."""
+        observations, stochastic_inputs = _observation_matrix(x, self.dimension)
+        n_sims = max(observations.shape[1], _parameter_n_sims(self.alpha) or 1)
+        if observations.shape[1] not in (1, n_sims):
+            raise ValueError("Observations and stochastic parameters must have compatible simulation counts.")
+        observations = xp.broadcast_to(observations, (self.dimension, n_sims))
+        alpha = _active_parameter_matrix(self.alpha, n_sims)
+        valid = xp.all(observations > 0, axis=0) & xp.isclose(xp.sum(observations, axis=0), 1.0)
+        with xp.errstate(divide="ignore", invalid="ignore"):
+            result = special.gammaln(xp.sum(alpha, axis=0)) - xp.sum(special.gammaln(alpha), axis=0)
+            result += xp.sum((alpha - 1) * xp.log(observations), axis=0)
+        result = xp.where(valid, result, -xp.inf)
+        return _density_result(result, (*stochastic_inputs, *self._parameters))
+
+
+class InvertedDirichlet(MultivariateDistributionBase):
+    r"""Inverted Dirichlet distribution on the positive orthant.
+
+    For :math:`d` positive components and :math:`d+1` positive parameters,
+
+    .. math::
+
+        f(x) = \frac{\Gamma(\alpha_0)}{\prod_{i=1}^{d+1}\Gamma(\alpha_i)}
+        \frac{\prod_{i=1}^d x_i^{\alpha_i-1}}
+        {(1+\sum_{i=1}^d x_i)^{\alpha_0}},
+        \qquad \alpha_0=\sum_{i=1}^{d+1}\alpha_i.
+
+    It can be generated by dividing the first :math:`d` independent gamma
+    variables by the final gamma variable.
+
+    Parameters:
+        alpha: Positive parameters. The final value controls the common denominator.
+        component_names: Optional names for the generated components.
+        dim_name: Name of the component dimension.
+
+    References:
+        Tiao, G. G. and Guttman, I. (1965). The Inverted Dirichlet
+        Distribution with Applications. Journal of the American Statistical
+        Association 60(311), 793--805.
+    """
+
+    def __init__(
+        self,
+        alpha: MultivariateParameter,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        dim_name: str = "component",
+    ) -> None:
+        """Initialize an inverted Dirichlet distribution."""
+        self.alpha, parameter_names = _validate_positive_parameter_vector(alpha, "alpha", minimum_length=2)
+        names = parameter_names[:-1] if parameter_names is not None else None
+        super().__init__(
+            len(self.alpha) - 1,
+            component_names=names if component_names is None else component_names,
+            dim_name=dim_name,
+        )
+
+    @property
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        return tuple(self.alpha)
+
+    def _generate_matrix(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        alpha = _parameter_matrix(self.alpha, n_sims, rng)
+        gamma = rng.gamma(alpha, 1.0)
+        return gamma[:-1] / gamma[-1]
+
+    def logpdf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint log probability density."""
+        observations, stochastic_inputs = _observation_matrix(x, self.dimension)
+        n_sims = max(observations.shape[1], _parameter_n_sims(self.alpha) or 1)
+        if observations.shape[1] not in (1, n_sims):
+            raise ValueError("Observations and stochastic parameters must have compatible simulation counts.")
+        observations = xp.broadcast_to(observations, (self.dimension, n_sims))
+        alpha = _active_parameter_matrix(self.alpha, n_sims)
+        valid = xp.all(observations > 0, axis=0)
+        with xp.errstate(divide="ignore", invalid="ignore"):
+            result = special.gammaln(xp.sum(alpha, axis=0)) - xp.sum(special.gammaln(alpha), axis=0)
+            result += xp.sum((alpha[:-1] - 1) * xp.log(observations), axis=0)
+            result -= xp.sum(alpha, axis=0) * xp.log1p(xp.sum(observations, axis=0))
+        result = xp.where(valid, result, -xp.inf)
+        return _density_result(result, (*stochastic_inputs, *self._parameters))
+
+
+class GeneralizedDirichlet(MultivariateDistributionBase):
+    r"""Connor--Mosimann generalized Dirichlet distribution.
+
+    Let :math:`V_i` be independent beta variables with parameters
+    :math:`(\alpha_i,\beta_i)`. The simplex components are constructed by
+
+    .. math::
+
+        X_i = V_i\prod_{j<i}(1-V_j), \qquad
+        X_{d+1}=\prod_{j=1}^d(1-V_j).
+
+    This parameterisation permits a richer covariance structure than the
+    Dirichlet distribution. The generated result includes the final remainder,
+    so its :math:`d+1` components sum to one.
+
+    Parameters:
+        alpha: First positive beta shape for each stick-breaking step.
+        beta: Second positive beta shape for each stick-breaking step.
+        component_names: Optional names for all generated components, including the remainder.
+        dim_name: Name of the component dimension.
+
+    References:
+        Connor, R. J. and Mosimann, J. E. (1969). Concepts of Independence for
+        Proportions with a Generalization of the Dirichlet Distribution.
+        Journal of the American Statistical Association 64(325), 194--206.
+    """
+
+    def __init__(
+        self,
+        alpha: MultivariateParameter,
+        beta: MultivariateParameter,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        dim_name: str = "component",
+    ) -> None:
+        """Initialize a generalized Dirichlet distribution."""
+        self.alpha, _ = _validate_positive_parameter_vector(alpha, "alpha")
+        self.beta, _ = _validate_positive_parameter_vector(beta, "beta")
+        if len(self.alpha) != len(self.beta):
+            raise ValueError("alpha and beta must have the same length.")
+        super().__init__(len(self.alpha) + 1, component_names=component_names, dim_name=dim_name)
+
+    @property
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        return (*self.alpha, *self.beta)
+
+    def _generate_matrix(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        alpha = _parameter_matrix(self.alpha, n_sims, rng)
+        beta = _parameter_matrix(self.beta, n_sims, rng)
+        breaks = rng.beta(alpha, beta)
+        components = []
+        backend = np if _is_numpy_rng(rng) else xp
+        remainder = backend.ones(n_sims)
+        for index in range(len(self.alpha)):
+            component = remainder * breaks[index]
+            components.append(component)
+            remainder = remainder - component
+        components.append(remainder)
+        return backend.stack(components, axis=0)
+
+    def logpdf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint log probability density."""
+        observations, stochastic_inputs = _observation_matrix(x, self.dimension)
+        parameter_n_sims = _parameter_n_sims(self._parameters) or 1
+        n_sims = max(observations.shape[1], parameter_n_sims)
+        if observations.shape[1] not in (1, n_sims):
+            raise ValueError("Observations and stochastic parameters must have compatible simulation counts.")
+        observations = xp.broadcast_to(observations, (self.dimension, n_sims))
+        alpha = _active_parameter_matrix(self.alpha, n_sims)
+        beta = _active_parameter_matrix(self.beta, n_sims)
+        valid = xp.all(observations > 0, axis=0) & xp.isclose(xp.sum(observations, axis=0), 1.0)
+        remainder = xp.ones(n_sims)
+        result = xp.zeros(n_sims)
+        with xp.errstate(divide="ignore", invalid="ignore"):
+            for index in range(len(self.alpha)):
+                proportion = observations[index] / remainder
+                result += (alpha[index] - 1) * xp.log(proportion)
+                result += (beta[index] - 1) * xp.log1p(-proportion)
+                result -= special.betaln(alpha[index], beta[index]) + xp.log(remainder)
+                remainder = remainder - observations[index]
+        result = xp.where(valid, result, -xp.inf)
+        return _density_result(result, (*stochastic_inputs, *self._parameters))
+
+
+class InvertedGeneralizedDirichlet(MultivariateDistributionBase):
+    r"""Inverted generalized Dirichlet distribution.
+
+    Let :math:`R_i` be independent beta-prime variables with parameters
+    :math:`(\alpha_i,\beta_i)`. The positive components are constructed by
+
+    .. math::
+
+        X_1=R_1, \qquad
+        X_i=R_i\left(1+\sum_{j<i}X_j\right), \quad i=2,\ldots,d.
+
+    Equivalently, its density is
+
+    .. math::
+
+        f(x)=\prod_{i=1}^d\frac{x_i^{\alpha_i-1}}{B(\alpha_i,\beta_i)}
+        \left(1+\sum_{j=1}^i x_j\right)^{-\gamma_i},
+        \qquad \gamma_i=\alpha_i+\beta_i-\beta_{i+1},
+
+    with :math:`\beta_{d+1}=0`. It reduces to an inverted Dirichlet when
+    :math:`\gamma_i=0` for :math:`i<d`.
+
+    Parameters:
+        alpha: First positive beta-prime shape for each component.
+        beta: Second positive beta-prime shape for each component.
+        component_names: Optional names for the generated components.
+        dim_name: Name of the component dimension.
+
+    References:
+        Lingappaiah, G. S. (1976). On the Generalized Inverted Dirichlet
+        Distribution. Demonstratio Mathematica 9(2), 423--433.
+    """
+
+    def __init__(
+        self,
+        alpha: MultivariateParameter,
+        beta: MultivariateParameter,
+        *,
+        component_names: t.Sequence[str] | None = None,
+        dim_name: str = "component",
+    ) -> None:
+        """Initialize an inverted generalized Dirichlet distribution."""
+        self.alpha, parameter_names = _validate_positive_parameter_vector(alpha, "alpha")
+        self.beta, _ = _validate_positive_parameter_vector(beta, "beta")
+        if len(self.alpha) != len(self.beta):
+            raise ValueError("alpha and beta must have the same length.")
+        super().__init__(
+            len(self.alpha),
+            component_names=parameter_names if component_names is None else component_names,
+            dim_name=dim_name,
+        )
+
+    @property
+    def _parameters(self) -> tuple[DistributionParameter, ...]:
+        return (*self.alpha, *self.beta)
+
+    def _generate_matrix(self, n_sims: int, rng: RandomGenerator) -> t.Any:
+        alpha = _parameter_matrix(self.alpha, n_sims, rng)
+        beta = _parameter_matrix(self.beta, n_sims, rng)
+        ratios = rng.gamma(alpha, 1.0) / rng.gamma(beta, 1.0)
+        components = []
+        backend = np if _is_numpy_rng(rng) else xp
+        cumulative = backend.ones(n_sims)
+        for index in range(self.dimension):
+            component = ratios[index] * cumulative
+            components.append(component)
+            cumulative = cumulative + component
+        return backend.stack(components, axis=0)
+
+    def logpdf(self, x: MultivariateInput) -> DensityResult:
+        """Compute the joint log probability density."""
+        observations, stochastic_inputs = _observation_matrix(x, self.dimension)
+        parameter_n_sims = _parameter_n_sims(self._parameters) or 1
+        n_sims = max(observations.shape[1], parameter_n_sims)
+        if observations.shape[1] not in (1, n_sims):
+            raise ValueError("Observations and stochastic parameters must have compatible simulation counts.")
+        observations = xp.broadcast_to(observations, (self.dimension, n_sims))
+        alpha = _active_parameter_matrix(self.alpha, n_sims)
+        beta = _active_parameter_matrix(self.beta, n_sims)
+        valid = xp.all(observations > 0, axis=0)
+        cumulative = xp.ones(n_sims)
+        result = xp.zeros(n_sims)
+        with xp.errstate(divide="ignore", invalid="ignore"):
+            for index in range(self.dimension):
+                ratio = observations[index] / cumulative
+                result += (alpha[index] - 1) * xp.log(ratio)
+                result -= (alpha[index] + beta[index]) * xp.log1p(ratio)
+                result -= special.betaln(alpha[index], beta[index]) + xp.log(cumulative)
+                cumulative = cumulative + observations[index]
+        result = xp.where(valid, result, -xp.inf)
+        return _density_result(result, (*stochastic_inputs, *self._parameters))
+
+
+__all__ = [
+    "Dirichlet",
+    "GeneralizedDirichlet",
+    "InvertedDirichlet",
+    "InvertedGeneralizedDirichlet",
+    "MultivariateDistributionBase",
+    "MultivariateNormal",
+    "MultivariateStudentsT",
+]

--- a/src/pal/multivariate_distributions.py
+++ b/src/pal/multivariate_distributions.py
@@ -58,7 +58,8 @@ def _validate_parameter_vector(
         raise ValueError(f"{name} must contain at least {minimum_length} value(s).")
     for value in values:
         raw = value.values if isinstance(value, StochasticScalar) else value
-        if bool(xp.any(~xp.isfinite(to_backend(raw)))):
+        backend_value = xp.asarray(to_backend(raw))
+        if bool(xp.any(~xp.isfinite(backend_value))):
             raise ValueError(f"{name} values must be finite.")
     return values, names
 
@@ -73,7 +74,8 @@ def _validate_positive_parameter_vector(
     values, names = _validate_parameter_vector(parameter, name, minimum_length=minimum_length)
     for value in values:
         raw = value.values if isinstance(value, StochasticScalar) else value
-        if bool(xp.any(to_backend(raw) <= 0)):
+        backend_value = xp.asarray(to_backend(raw))
+        if bool(xp.any(backend_value <= 0)):
             raise ValueError(f"{name} values must be positive.")
     return values, names
 
@@ -135,6 +137,8 @@ def _validate_matrix(matrix: npt.ArrayLike, dimension: int, name: str) -> t.Any:
         raise ValueError(f"{name} values must be finite.")
     if not bool(xp.allclose(values, values.T)):
         raise ValueError(f"{name} must be symmetric.")
+    if float(xp.linalg.eigvalsh(values).min().item()) <= 0:
+        raise ValueError(f"{name} must be positive definite.")
     try:
         return xp.linalg.cholesky(values)
     except xp.linalg.LinAlgError as error:
@@ -368,7 +372,8 @@ class MultivariateStudentsT(MultivariateDistributionBase):
     ) -> None:
         """Initialize a multivariate Student's t distribution."""
         raw_nu = nu.values if isinstance(nu, StochasticScalar) else nu
-        if bool(xp.any(~xp.isfinite(to_backend(raw_nu)))) or bool(xp.any(to_backend(raw_nu) <= 0)):
+        backend_nu = xp.asarray(to_backend(raw_nu))
+        if bool(xp.any(~xp.isfinite(backend_nu))) or bool(xp.any(backend_nu <= 0)):
             raise ValueError("nu must be finite and positive.")
         self.nu = nu
         self.mean, parameter_names = _validate_parameter_vector(mean, "mean")

--- a/src/pal/variables.py
+++ b/src/pal/variables.py
@@ -181,10 +181,12 @@ class ProteusVariable(t.Generic[T]):
             self.values.values() if isinstance(self.values, dict) else self.values  # type: ignore[reportUnknownMemberType]
         ):
             if isinstance(value, ProteusVariable):
-                if self._dimension_set.intersection(value._dimension_set) or self.dim_name == value.dim_name:
+                if self.dim_name in value._dimension_set:
                     raise ValueError("Duplicate dimension names in ProteusVariable hierarchy.")
-                self._dimension_set.intersection_update(value.dimensions)
-                self.dimensions.extend(value.dimensions)
+                for dimension in value.dimensions:
+                    if dimension not in self._dimension_set:
+                        self._dimension_set.add(dimension)
+                        self.dimensions.append(dimension)
 
             if self.n_sims is None:
                 if isinstance(value, ProteusStochasticVariable):

--- a/tests/test_gpu_backend.py
+++ b/tests/test_gpu_backend.py
@@ -7,14 +7,17 @@ from pal import (
     Dirichlet,
     GeneralizedDirichlet,
     InverseGaussian,
+    InverseWishart,
     InvertedDirichlet,
     InvertedGeneralizedDirichlet,
+    Multinomial,
     MultivariateNormal,
     MultivariateStudentsT,
     NegBinomial,
     Normal,
     StochasticScalar,
     StudentsT,
+    Wishart,
     set_random_seed,
 )
 from pal._maths import xp
@@ -54,12 +57,18 @@ def test_generation_and_numpy_dispatch_do_not_transfer_to_host(monkeypatch: pyte
         inverted_dirichlet_distribution = InvertedDirichlet([2, 3, 8])
         generalized_dirichlet_distribution = GeneralizedDirichlet([2, 3], [4, 5])
         inverted_generalized_dirichlet_distribution = InvertedGeneralizedDirichlet([2, 3], [6, 8])
+        multinomial_distribution = Multinomial(20, [0.2, 0.3, 0.5])
+        wishart_distribution = Wishart(8, [[1, 0.2], [0.2, 0.7]])
+        inverse_wishart_distribution = InverseWishart(10, [[1, 0.2], [0.2, 0.7]])
         multivariate_normal = multivariate_normal_distribution.generate(256)
         multivariate_students_t = multivariate_students_t_distribution.generate(256)
         dirichlet = dirichlet_distribution.generate(256)
         inverted_dirichlet = inverted_dirichlet_distribution.generate(256)
         generalized_dirichlet = generalized_dirichlet_distribution.generate(256)
         inverted_generalized_dirichlet = inverted_generalized_dirichlet_distribution.generate(256)
+        multinomial = multinomial_distribution.generate(256)
+        wishart = wishart_distribution.generate(256)
+        inverse_wishart = inverse_wishart_distribution.generate(256)
         transformed = np.where(simulations > 100, np.exp(simulations / 100), np.square(simulations / 100))
 
         assert type(config.rng).__module__.startswith("cupy")
@@ -75,6 +84,7 @@ def test_generation_and_numpy_dispatch_do_not_transfer_to_host(monkeypatch: pyte
             inverted_dirichlet,
             generalized_dirichlet,
             inverted_generalized_dirichlet,
+            multinomial,
         )
         multivariate_densities = (
             multivariate_normal_distribution.logpdf(multivariate_normal),
@@ -83,8 +93,17 @@ def test_generation_and_numpy_dispatch_do_not_transfer_to_host(monkeypatch: pyte
             inverted_dirichlet_distribution.logpdf(inverted_dirichlet),
             generalized_dirichlet_distribution.logpdf(generalized_dirichlet),
             inverted_generalized_dirichlet_distribution.logpdf(inverted_generalized_dirichlet),
+            multinomial_distribution.logpmf(multinomial),
+            wishart_distribution.logpdf(wishart),
+            inverse_wishart_distribution.logpdf(inverse_wishart),
         )
         assert all(isinstance(component.values, xp.ndarray) for sample in multivariate_samples for component in sample)
+        assert all(
+            isinstance(entry.values, xp.ndarray)
+            for sample in (wishart, inverse_wishart)
+            for row in sample
+            for entry in row
+        )
         assert all(
             isinstance(density, StochasticScalar) and isinstance(density.values, xp.ndarray)
             for density in multivariate_densities

--- a/tests/test_gpu_backend.py
+++ b/tests/test_gpu_backend.py
@@ -3,7 +3,20 @@
 import numpy as np
 import pytest
 
-from pal import InverseGaussian, NegBinomial, Normal, StudentsT, set_random_seed
+from pal import (
+    Dirichlet,
+    GeneralizedDirichlet,
+    InverseGaussian,
+    InvertedDirichlet,
+    InvertedGeneralizedDirichlet,
+    MultivariateNormal,
+    MultivariateStudentsT,
+    NegBinomial,
+    Normal,
+    StochasticScalar,
+    StudentsT,
+    set_random_seed,
+)
 from pal._maths import xp
 from pal.config import config
 from pal.copulas import StudentsTCopula
@@ -35,6 +48,18 @@ def test_generation_and_numpy_dispatch_do_not_transfer_to_host(monkeypatch: pyte
         students_t_copula = StudentsTCopula([[1, 0.5], [0.5, 1]], 5).generate(4096)
         inverse_gaussian = InverseGaussian(2, 3).generate(256)
         negative_binomial = NegBinomial(4, 0.5).generate(256)
+        multivariate_normal_distribution = MultivariateNormal([0, 0], [[1, 0.5], [0.5, 1]])
+        multivariate_students_t_distribution = MultivariateStudentsT(5, [0, 0], [[1, 0.5], [0.5, 1]])
+        dirichlet_distribution = Dirichlet([2, 3, 4])
+        inverted_dirichlet_distribution = InvertedDirichlet([2, 3, 8])
+        generalized_dirichlet_distribution = GeneralizedDirichlet([2, 3], [4, 5])
+        inverted_generalized_dirichlet_distribution = InvertedGeneralizedDirichlet([2, 3], [6, 8])
+        multivariate_normal = multivariate_normal_distribution.generate(256)
+        multivariate_students_t = multivariate_students_t_distribution.generate(256)
+        dirichlet = dirichlet_distribution.generate(256)
+        inverted_dirichlet = inverted_dirichlet_distribution.generate(256)
+        generalized_dirichlet = generalized_dirichlet_distribution.generate(256)
+        inverted_generalized_dirichlet = inverted_generalized_dirichlet_distribution.generate(256)
         transformed = np.where(simulations > 100, np.exp(simulations / 100), np.square(simulations / 100))
 
         assert type(config.rng).__module__.startswith("cupy")
@@ -43,6 +68,27 @@ def test_generation_and_numpy_dispatch_do_not_transfer_to_host(monkeypatch: pyte
         assert all(isinstance(margin.values, xp.ndarray) for margin in students_t_copula)
         assert isinstance(inverse_gaussian.values, xp.ndarray)
         assert isinstance(negative_binomial.values, xp.ndarray)
+        multivariate_samples = (
+            multivariate_normal,
+            multivariate_students_t,
+            dirichlet,
+            inverted_dirichlet,
+            generalized_dirichlet,
+            inverted_generalized_dirichlet,
+        )
+        multivariate_densities = (
+            multivariate_normal_distribution.logpdf(multivariate_normal),
+            multivariate_students_t_distribution.logpdf(multivariate_students_t),
+            dirichlet_distribution.logpdf(dirichlet),
+            inverted_dirichlet_distribution.logpdf(inverted_dirichlet),
+            generalized_dirichlet_distribution.logpdf(generalized_dirichlet),
+            inverted_generalized_dirichlet_distribution.logpdf(inverted_generalized_dirichlet),
+        )
+        assert all(isinstance(component.values, xp.ndarray) for sample in multivariate_samples for component in sample)
+        assert all(
+            isinstance(density, StochasticScalar) and isinstance(density.values, xp.ndarray)
+            for density in multivariate_densities
+        )
         assert isinstance(transformed.values, xp.ndarray)
         assert not host_to_device_transfers
     finally:

--- a/tests/test_multivariate_distributions.py
+++ b/tests/test_multivariate_distributions.py
@@ -1,0 +1,197 @@
+"""Tests for multivariate probability distributions."""
+
+import numpy as np
+import pytest
+import scipy.stats
+
+from pal import (
+    Dirichlet,
+    GeneralizedDirichlet,
+    InvertedDirichlet,
+    InvertedGeneralizedDirichlet,
+    MultivariateNormal,
+    MultivariateStudentsT,
+    ProteusVariable,
+    StochasticScalar,
+    set_random_seed,
+)
+from pal._maths import asnumpy, xp
+
+
+def _sample_matrix(samples: ProteusVariable[StochasticScalar]) -> np.ndarray:
+    """Return simulations in rows and components in columns."""
+    return asnumpy(xp.stack([component.values for component in samples], axis=1))
+
+
+def test_multivariate_normal_density_and_moments() -> None:
+    """Match SciPy's density and the theoretical first two moments."""
+    set_random_seed(48291)
+    mean = [1.0, -2.0, 0.5]
+    covariance = np.array(
+        [
+            [2.0, 0.6, -0.2],
+            [0.6, 1.5, 0.4],
+            [-0.2, 0.4, 1.0],
+        ]
+    )
+    distribution = MultivariateNormal(
+        mean,
+        covariance,
+        component_names=["property", "casualty", "market"],
+    )
+
+    point = np.array([0.2, -1.3, 0.8])
+    assert distribution.logpdf(point) == pytest.approx(
+        scipy.stats.multivariate_normal.logpdf(point, mean=mean, cov=covariance)
+    )
+    assert distribution.pdf(point) == pytest.approx(
+        scipy.stats.multivariate_normal.pdf(point, mean=mean, cov=covariance)
+    )
+
+    samples = distribution.generate(120_000)
+    values = _sample_matrix(samples)
+    assert list(samples.values) == ["property", "casualty", "market"]
+    assert np.mean(values, axis=0) == pytest.approx(mean, abs=0.02)
+    assert np.cov(values, rowvar=False) == pytest.approx(covariance, abs=0.025)
+    assert all(component.coupled_variable_group is samples[0].coupled_variable_group for component in samples)
+
+
+def test_multivariate_students_t_density_and_moments() -> None:
+    """Match SciPy's density and the finite theoretical covariance."""
+    set_random_seed(19763)
+    nu = 8.0
+    mean = np.array([0.5, -1.0])
+    scale = np.array([[1.2, 0.45], [0.45, 0.8]])
+    distribution = MultivariateStudentsT(nu, mean, scale)
+
+    point = np.array([1.1, -0.4])
+    assert distribution.logpdf(point) == pytest.approx(
+        scipy.stats.multivariate_t.logpdf(point, loc=mean, shape=scale, df=nu)
+    )
+
+    samples = distribution.generate(150_000)
+    values = _sample_matrix(samples)
+    assert np.mean(values, axis=0) == pytest.approx(mean, abs=0.02)
+    assert np.cov(values, rowvar=False) == pytest.approx(nu / (nu - 2) * scale, abs=0.035)
+
+
+def test_dirichlet_density_simplex_and_moments() -> None:
+    """Match SciPy's density and Dirichlet moments."""
+    set_random_seed(58123)
+    alpha = np.array([2.0, 3.0, 5.0])
+    distribution = Dirichlet(alpha)
+    point = np.array([0.2, 0.3, 0.5])
+
+    assert distribution.logpdf(point) == pytest.approx(scipy.stats.dirichlet.logpdf(point, alpha))
+    assert distribution.pdf(point) == pytest.approx(scipy.stats.dirichlet.pdf(point, alpha))
+    assert distribution.pdf([0.2, 0.3, 0.6]) == 0.0
+
+    samples = distribution.generate(120_000)
+    values = _sample_matrix(samples)
+    total = alpha.sum()
+    expected_covariance = (np.diag(alpha * (total - alpha)) - (np.outer(alpha, alpha) - np.diag(alpha**2))) / (
+        total**2 * (total + 1)
+    )
+    assert np.sum(values, axis=1) == pytest.approx(np.ones(len(values)), abs=1e-12)
+    assert np.mean(values, axis=0) == pytest.approx(alpha / total, abs=0.003)
+    assert np.cov(values, rowvar=False) == pytest.approx(expected_covariance, abs=0.001)
+
+
+def test_inverted_dirichlet_density_and_moments() -> None:
+    """Match the theoretical density, mean, variance, and covariance."""
+    set_random_seed(66142)
+    alpha = np.array([2.0, 3.0, 10.0])
+    distribution = InvertedDirichlet(alpha)
+    point = np.array([0.4, 1.2])
+    log_normalizer = scipy.special.gammaln(alpha.sum()) - scipy.special.gammaln(alpha).sum()
+    expected_logpdf = log_normalizer + np.sum((alpha[:-1] - 1) * np.log(point)) - alpha.sum() * np.log1p(point.sum())
+    assert distribution.logpdf(point) == pytest.approx(expected_logpdf)
+
+    samples = distribution.generate(160_000)
+    values = _sample_matrix(samples)
+    tail = alpha[-1]
+    expected_mean = alpha[:-1] / (tail - 1)
+    expected_variance = alpha[:-1] * (alpha[:-1] + tail - 1) / ((tail - 1) ** 2 * (tail - 2))
+    expected_covariance = alpha[0] * alpha[1] / ((tail - 1) ** 2 * (tail - 2))
+    assert np.mean(values, axis=0) == pytest.approx(expected_mean, abs=0.006)
+    assert np.var(values, axis=0) == pytest.approx(expected_variance, abs=0.004)
+    assert np.cov(values, rowvar=False)[0, 1] == pytest.approx(expected_covariance, abs=0.0015)
+
+
+def test_generalized_dirichlet_moments_and_dirichlet_reduction() -> None:
+    """Check stick-breaking means and the exact Dirichlet special case."""
+    set_random_seed(72913)
+    alpha = np.array([2.0, 4.0, 3.0])
+    beta = np.array([5.0, 2.0, 6.0])
+    distribution = GeneralizedDirichlet(alpha, beta)
+    samples = distribution.generate(120_000)
+    values = _sample_matrix(samples)
+
+    expected_mean = []
+    expected_remainder = 1.0
+    for alpha_i, beta_i in zip(alpha, beta, strict=True):
+        expected_mean.append(expected_remainder * alpha_i / (alpha_i + beta_i))
+        expected_remainder *= beta_i / (alpha_i + beta_i)
+    expected_mean.append(expected_remainder)
+    assert np.sum(values, axis=1) == pytest.approx(np.ones(len(values)), abs=1e-12)
+    assert np.mean(values, axis=0) == pytest.approx(expected_mean, abs=0.003)
+
+    dirichlet_alpha = np.array([2.0, 3.0, 4.0])
+    reduced = GeneralizedDirichlet(
+        alpha=dirichlet_alpha[:-1],
+        beta=[dirichlet_alpha[1:].sum(), dirichlet_alpha[2]],
+    )
+    point = np.array([0.2, 0.3, 0.5])
+    assert reduced.logpdf(point) == pytest.approx(scipy.stats.dirichlet.logpdf(point, dirichlet_alpha))
+
+
+def test_inverted_generalized_dirichlet_reduces_to_inverted_dirichlet() -> None:
+    """Check the inverted Dirichlet special case in density and moments."""
+    set_random_seed(91357)
+    alpha = np.array([2.0, 3.0])
+    beta = np.array([10.0, 12.0])
+    generalized = InvertedGeneralizedDirichlet(alpha, beta)
+    inverted = InvertedDirichlet([2.0, 3.0, 10.0])
+    point = np.array([0.4, 1.2])
+    assert generalized.logpdf(point) == pytest.approx(inverted.logpdf(point))
+
+    samples = generalized.generate(160_000)
+    values = _sample_matrix(samples)
+    expected_mean = np.array([2.0 / 9.0, 3.0 / 9.0])
+    expected_covariance = 2.0 * 3.0 / (9.0**2 * 8.0)
+    assert np.mean(values, axis=0) == pytest.approx(expected_mean, abs=0.006)
+    assert np.cov(values, rowvar=False)[0, 1] == pytest.approx(expected_covariance, abs=0.0015)
+
+
+def test_multivariate_distribution_stochastic_parameter_coupling() -> None:
+    """Couple every output component to every stochastic parameter."""
+    n_sims = 2_000
+    stochastic_alpha = StochasticScalar(xp.full(n_sims, 2.0))
+    distribution = Dirichlet([stochastic_alpha, 3.0, 4.0])
+    samples = distribution.generate(n_sims)
+
+    group = samples[0].coupled_variable_group
+    assert stochastic_alpha.coupled_variable_group is group
+    assert all(component.coupled_variable_group is group for component in samples)
+
+    density = distribution.logpdf(samples)
+    assert isinstance(density, StochasticScalar)
+    assert density.coupled_variable_group is samples[0].coupled_variable_group
+    assert density.coupled_variable_group is stochastic_alpha.coupled_variable_group
+
+
+@pytest.mark.parametrize(
+    ("constructor", "match"),
+    [
+        (lambda: MultivariateNormal([0.0, 0.0], [[1.0, 2.0], [2.0, 1.0]]), "positive definite"),
+        (lambda: MultivariateStudentsT(0.0, [0.0], [[1.0]]), "nu"),
+        (lambda: Dirichlet([1.0, -1.0]), "positive"),
+        (lambda: InvertedDirichlet([1.0]), "at least 2"),
+        (lambda: GeneralizedDirichlet([1.0, 2.0], [1.0]), "same length"),
+        (lambda: InvertedGeneralizedDirichlet([1.0], [0.0]), "positive"),
+    ],
+)
+def test_multivariate_distribution_validation(constructor: object, match: str) -> None:
+    """Reject invalid dimensions, matrices, degrees of freedom, and shape parameters."""
+    with pytest.raises(ValueError, match=match):
+        constructor()  # type: ignore[operator]

--- a/tests/test_multivariate_distributions.py
+++ b/tests/test_multivariate_distributions.py
@@ -7,12 +7,15 @@ import scipy.stats
 from pal import (
     Dirichlet,
     GeneralizedDirichlet,
+    InverseWishart,
     InvertedDirichlet,
     InvertedGeneralizedDirichlet,
+    Multinomial,
     MultivariateNormal,
     MultivariateStudentsT,
     ProteusVariable,
     StochasticScalar,
+    Wishart,
     set_random_seed,
 )
 from pal._maths import asnumpy, xp
@@ -21,6 +24,18 @@ from pal._maths import asnumpy, xp
 def _sample_matrix(samples: ProteusVariable[StochasticScalar]) -> np.ndarray:
     """Return simulations in rows and components in columns."""
     return asnumpy(xp.stack([component.values for component in samples], axis=1))
+
+
+def _matrix_sample_array(
+    samples: ProteusVariable[ProteusVariable[StochasticScalar]],
+) -> np.ndarray:
+    """Return matrix simulations with shape ``(n_sims, rows, columns)``."""
+    return asnumpy(
+        xp.stack(
+            [xp.stack([entry.values for entry in row], axis=1) for row in samples],
+            axis=1,
+        )
+    )
 
 
 def test_multivariate_normal_density_and_moments() -> None:
@@ -73,6 +88,78 @@ def test_multivariate_students_t_density_and_moments() -> None:
     values = _sample_matrix(samples)
     assert np.mean(values, axis=0) == pytest.approx(mean, abs=0.02)
     assert np.cov(values, rowvar=False) == pytest.approx(nu / (nu - 2) * scale, abs=0.035)
+
+
+def test_multinomial_probability_and_moments() -> None:
+    """Match SciPy's probability mass and the theoretical moments."""
+    set_random_seed(34781)
+    n = 20
+    probabilities = np.array([0.2, 0.3, 0.5])
+    distribution = Multinomial(
+        n,
+        probabilities,
+        component_names=["property", "casualty", "specialty"],
+    )
+    point = np.array([4, 6, 10])
+
+    assert distribution.logpmf(point) == pytest.approx(scipy.stats.multinomial.logpmf(point, n, probabilities))
+    assert distribution.pmf(point) == pytest.approx(scipy.stats.multinomial.pmf(point, n, probabilities))
+    assert distribution.pmf([4, 6, 9]) == 0.0
+    assert distribution.pmf([4, 5.5, 10.5]) == 0.0
+
+    samples = distribution.generate(100_000)
+    values = _sample_matrix(samples)
+    expected_covariance = n * (np.diag(probabilities) - np.outer(probabilities, probabilities))
+    assert list(samples.values) == ["property", "casualty", "specialty"]
+    assert np.sum(values, axis=1) == pytest.approx(np.full(len(values), n))
+    assert np.mean(values, axis=0) == pytest.approx(n * probabilities, abs=0.025)
+    assert np.cov(values, rowvar=False) == pytest.approx(expected_covariance, abs=0.04)
+
+
+def test_wishart_density_and_moments() -> None:
+    """Match SciPy's density and the theoretical mean matrix."""
+    set_random_seed(74219)
+    df = 8.0
+    scale = np.array([[1.0, 0.2], [0.2, 0.7]])
+    distribution = Wishart(
+        df,
+        scale,
+        component_names=["property", "casualty"],
+    )
+    point = np.array([[5.0, 0.4], [0.4, 3.0]])
+
+    assert distribution.logpdf(point) == pytest.approx(scipy.stats.wishart.logpdf(point, df=df, scale=scale))
+    assert distribution.pdf(point) == pytest.approx(scipy.stats.wishart.pdf(point, df=df, scale=scale))
+    assert distribution.pdf([[1.0, 2.0], [2.0, 1.0]]) == 0.0
+
+    samples = distribution.generate(60_000)
+    values = _matrix_sample_array(samples)
+    assert list(samples.values) == ["property", "casualty"]
+    assert list(samples[0].values) == ["property", "casualty"]
+    assert samples.dimensions == ["row", "column"]
+    assert np.mean(values, axis=0) == pytest.approx(df * scale, abs=0.04)
+    assert values == pytest.approx(np.swapaxes(values, 1, 2), abs=1e-12)
+    assert np.all(np.linalg.eigvalsh(values[:1_000]) > 0)
+
+
+def test_inverse_wishart_density_and_moments() -> None:
+    """Match SciPy's density and the finite theoretical mean matrix."""
+    set_random_seed(96541)
+    df = 12.0
+    scale = np.array([[1.0, 0.2], [0.2, 0.7]])
+    distribution = InverseWishart(df, scale)
+    point = np.array([[0.2, 0.03], [0.03, 0.15]])
+
+    assert distribution.logpdf(point) == pytest.approx(scipy.stats.invwishart.logpdf(point, df=df, scale=scale))
+    assert distribution.pdf(point) == pytest.approx(scipy.stats.invwishart.pdf(point, df=df, scale=scale))
+    assert distribution.pdf([[1.0, 2.0], [2.0, 1.0]]) == 0.0
+
+    samples = distribution.generate(80_000)
+    values = _matrix_sample_array(samples)
+    expected_mean = scale / (df - len(scale) - 1)
+    assert np.mean(values, axis=0) == pytest.approx(expected_mean, abs=0.0015)
+    assert values == pytest.approx(np.swapaxes(values, 1, 2), abs=1e-12)
+    assert np.all(np.linalg.eigvalsh(values[:1_000]) > 0)
 
 
 def test_dirichlet_density_simplex_and_moments() -> None:
@@ -180,6 +267,41 @@ def test_multivariate_distribution_stochastic_parameter_coupling() -> None:
     assert density.coupled_variable_group is stochastic_alpha.coupled_variable_group
 
 
+def test_multinomial_stochastic_parameter_coupling() -> None:
+    """Couple multinomial counts and probability mass to stochastic parameters."""
+    n_sims = 2_000
+    stochastic_n = StochasticScalar(xp.full(n_sims, 20))
+    stochastic_probability = StochasticScalar(xp.full(n_sims, 0.2))
+    distribution = Multinomial(stochastic_n, [stochastic_probability, 0.3, 0.5])
+    samples = distribution.generate(n_sims)
+
+    group = samples[0].coupled_variable_group
+    assert stochastic_n.coupled_variable_group is group
+    assert stochastic_probability.coupled_variable_group is group
+    assert all(component.coupled_variable_group is group for component in samples)
+    probability = distribution.logpmf(samples)
+    assert isinstance(probability, StochasticScalar)
+    assert probability.coupled_variable_group is samples[0].coupled_variable_group
+    assert probability.coupled_variable_group is stochastic_n.coupled_variable_group
+    assert probability.coupled_variable_group is stochastic_probability.coupled_variable_group
+
+
+def test_matrix_distribution_stochastic_parameter_coupling() -> None:
+    """Couple every matrix entry and its density to stochastic degrees of freedom."""
+    n_sims = 1_000
+    stochastic_df = StochasticScalar(xp.full(n_sims, 8.0))
+    distribution = Wishart(stochastic_df, [[1.0, 0.2], [0.2, 0.7]])
+    samples = distribution.generate(n_sims)
+
+    group = samples[0][0].coupled_variable_group
+    assert stochastic_df.coupled_variable_group is group
+    assert all(entry.coupled_variable_group is group for row in samples for entry in row)
+    density = distribution.logpdf(samples)
+    assert isinstance(density, StochasticScalar)
+    assert density.coupled_variable_group is samples[0][0].coupled_variable_group
+    assert density.coupled_variable_group is stochastic_df.coupled_variable_group
+
+
 @pytest.mark.parametrize(
     ("constructor", "match"),
     [
@@ -189,6 +311,10 @@ def test_multivariate_distribution_stochastic_parameter_coupling() -> None:
         (lambda: InvertedDirichlet([1.0]), "at least 2"),
         (lambda: GeneralizedDirichlet([1.0, 2.0], [1.0]), "same length"),
         (lambda: InvertedGeneralizedDirichlet([1.0], [0.0]), "positive"),
+        (lambda: Multinomial(-1, [0.5, 0.5]), "non-negative integers"),
+        (lambda: Multinomial(10, [0.4, 0.5]), "sum to one"),
+        (lambda: Wishart(1, [[1.0, 0.0], [0.0, 1.0]]), "df"),
+        (lambda: InverseWishart(3, [[1.0, 2.0], [2.0, 1.0]]), "positive definite"),
     ],
 )
 def test_multivariate_distribution_validation(constructor: object, match: str) -> None:

--- a/tests/test_variables_minimal.py
+++ b/tests/test_variables_minimal.py
@@ -214,6 +214,15 @@ def test_init_duplicate_dimensions():
         ProteusVariable("inner", {"a": nested, "b": 3})
 
 
+def test_init_repeated_nested_dimensions_are_recorded_once():
+    """Record a shared child dimension once across sibling variables."""
+    first = ProteusVariable("column", {"x": 1, "y": 2})
+    second = ProteusVariable("column", {"x": 3, "y": 4})
+    matrix = ProteusVariable("row", {"a": first, "b": second})
+
+    assert matrix.dimensions == ["row", "column"]
+
+
 def test_init_mismatched_n_sims():
     """Test that mismatched simulation counts raise ValueError."""
     with pytest.raises(ValueError, match="Number of simulations do not match"):


### PR DESCRIPTION
## Summary

- add `MultivariateNormal` and `MultivariateStudentsT`
- add `Multinomial`, `Dirichlet`, `InvertedDirichlet`, `GeneralizedDirichlet`, and `InvertedGeneralizedDirichlet`
- add matrix-valued `Wishart` and `InverseWishart` distributions using backend-resident Bartlett sampling
- return named `ProteusVariable[StochasticScalar]` components with shared coupling groups
- represent matrix draws as named nested row and column variables with coupled stochastic entries
- support stochastic vector parameters and stochastic degrees of freedom on the active NumPy/CuPy backend
- provide joint `pdf`/`logpdf` or `pmf`/`logpmf`, parameter validation, mathematical docstrings, and distribution-guide documentation
- extend GPU residency coverage to generation and density evaluation

## Validation

- 657 passed, 1 CUDA-only test skipped in the full CPU suite
- focused multivariate and GPU-backend tests pass
- distribution-guide code blocks pass
- Ruff lint and formatting pass
- Pyright: 0 errors
- Bandit and vulture pass
- RST math validator: 108 directives validated
- documentation build completes; its remaining warnings pre-date this branch
- the full local `--codeblocks` run has two pre-existing failures in `mirror-package/README.md` because its `pip` shell snippets are executed

## Parameterisation notes

- `GeneralizedDirichlet(alpha, beta)` uses Connor–Mosimann stick breaking and returns the explicit remainder component.
- `InvertedGeneralizedDirichlet(alpha, beta)` uses the beta-prime construction and reduces to `InvertedDirichlet` when the intermediate density exponents are zero.
- `Wishart(df, scale)` has mean `df * scale`; `InverseWishart(df, scale)` has mean `scale / (df - p - 1)` when it exists.
