### PR TITLE
Add hyperexponential and empirical distributions

### DIFF
--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -44,6 +44,7 @@ Continuous distributions
    pal.distributions.InverseGaussian
    pal.distributions.GeneralizedInverseGaussian
    pal.distributions.Exponential
+   pal.distributions.HyperExponential
    pal.distributions.Uniform
    pal.distributions.InverseExponential
 

--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -15,6 +15,7 @@ Discrete distributions
    pal.distributions.Binomial
    pal.distributions.HyperGeometric
    pal.distributions.Bernoulli
+   pal.distributions.Empirical
 
 Continuous distributions
 ------------------------

--- a/src/pal/__init__.py
+++ b/src/pal/__init__.py
@@ -19,9 +19,16 @@ from .config import *
 from .contracts import *
 from .distributions import *
 from .frequency_severity import *
+from .hyperexponential import HyperExponential
 from .multivariate_distributions import *
 from .stats import *
 from .variables import *
+
+# HyperExponential has vector-valued mixture parameters and is implemented in a
+# separate module. Expose it through the standard distributions namespace and
+# named-distribution generator API.
+setattr(distributions, "HyperExponential", HyperExponential)
+distributions.AVAILABLE_CONTINUOUS_DISTRIBUTIONS["hyperexponential"] = HyperExponential
 
 # ``variables`` depends on ``frequency_severity``, which in turn depends on the
 # univariate distributions module. Attach the multivariate API after those modules

--- a/src/pal/__init__.py
+++ b/src/pal/__init__.py
@@ -18,15 +18,18 @@ from . import distributions as distributions
 from .config import *
 from .contracts import *
 from .distributions import *
+from .empirical import Empirical
 from .frequency_severity import *
 from .hyperexponential import HyperExponential
 from .multivariate_distributions import *
 from .stats import *
 from .variables import *
 
-# HyperExponential has vector-valued mixture parameters and is implemented in a
-# separate module. Expose it through the standard distributions namespace and
-# named-distribution generator API.
+# Empirical and HyperExponential have vector-valued parameters and are
+# implemented in separate modules. Expose them through the standard
+# distributions namespace and named-distribution generator APIs.
+distributions.__dict__["Empirical"] = Empirical
+distributions.AVAILABLE_DISCRETE_DISTRIBUTIONS["empirical"] = Empirical
 distributions.__dict__["HyperExponential"] = HyperExponential
 distributions.AVAILABLE_CONTINUOUS_DISTRIBUTIONS["hyperexponential"] = HyperExponential
 

--- a/src/pal/__init__.py
+++ b/src/pal/__init__.py
@@ -27,7 +27,7 @@ from .variables import *
 # HyperExponential has vector-valued mixture parameters and is implemented in a
 # separate module. Expose it through the standard distributions namespace and
 # named-distribution generator API.
-setattr(distributions, "HyperExponential", HyperExponential)
+distributions.__dict__["HyperExponential"] = HyperExponential
 distributions.AVAILABLE_CONTINUOUS_DISTRIBUTIONS["hyperexponential"] = HyperExponential
 
 # ``variables`` depends on ``frequency_severity``, which in turn depends on the

--- a/src/pal/empirical.py
+++ b/src/pal/empirical.py
@@ -133,7 +133,7 @@ class Empirical(DiscreteDistributionBase):
         """Compute the generalized inverse empirical CDF."""
         probabilities = xp.asarray(u.values if isinstance(u, StochasticScalar) else u)
         invalid = (probabilities < 0) | (probabilities > 1) | xp.isnan(probabilities)
-        safe_probabilities = xp.clip(probabilities, 0.0, 1.0)
+        safe_probabilities = xp.where(invalid, 0.0, probabilities)
         indices = xp.searchsorted(self._cumulative_weights, safe_probabilities, side="left")
         quantiles = self._samples[indices].astype(float, copy=False)
         result = xp.where(invalid, xp.nan, quantiles)

--- a/src/pal/empirical.py
+++ b/src/pal/empirical.py
@@ -1,0 +1,150 @@
+"""Empirical distribution.
+
+This module contains a finite empirical distribution defined by observed samples
+and optional observation weights. It is separate from :mod:`pal.distributions`
+because its support and weights are vector-valued inputs rather than scalar
+distribution parameters.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from ._compat import override
+from ._maths import scalar_or_array, xp
+from .distributions import DiscreteDistributionBase, ReturnType
+from .stochastic_scalar import StochasticScalar
+from .types import DistributionParameter, RandomGenerator
+
+
+class Empirical(DiscreteDistributionBase):
+    r"""Empirical distribution defined by observed samples.
+
+    For observations :math:`x_1,\ldots,x_n` with non-negative weights
+    :math:`w_1,\ldots,w_n`, let
+
+    .. math::
+
+        p_i = \frac{w_i}{\sum_{j=1}^n w_j}.
+
+    The empirical cumulative distribution function is
+
+    .. math::
+
+        F(x) = \sum_{i=1}^n p_i\,\mathbf{1}\{x_i \leq x\}.
+
+    If ``weights`` is omitted, all observations receive equal probability
+    :math:`1/n`. The weights need not already sum to one; PAL normalises them
+    internally. Zero-weight observations are ignored.
+
+    The inverse CDF is the generalized inverse
+
+    .. math::
+
+        F^{-1}(u) = \inf\{x : F(x) \geq u\}, \qquad 0 \leq u \leq 1.
+
+    Generation resamples the observed values with replacement using the
+    empirical probabilities. The observed samples may be supplied directly as
+    a :class:`~pal.stochastic_scalar.StochasticScalar`; they are treated as the
+    fixed empirical support rather than as scenario-varying distribution
+    parameters, so resampled values are independent of the source coupling
+    group.
+
+    Parameters:
+        samples: One-dimensional finite numeric observations.
+        weights: Optional non-negative observation weights. Must have the same
+            length as ``samples`` and contain at least one positive value.
+    """
+
+    def __init__(self, samples: t.Any, weights: t.Any | None = None) -> None:
+        """Initialize an empirical distribution.
+
+        Args:
+            samples: One-dimensional finite numeric observations.
+            weights: Optional non-negative observation weights.
+        """
+        sample_values = samples.values if isinstance(samples, StochasticScalar) else samples
+        try:
+            sample_array = xp.asarray(sample_values)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("samples must be a one-dimensional numeric sequence.") from exc
+
+        if sample_array.ndim != 1:
+            raise ValueError("samples must be one-dimensional.")
+        if sample_array.size == 0:
+            raise ValueError("samples must contain at least one observation.")
+        if sample_array.dtype.kind not in "iuf":
+            raise TypeError("samples must contain numeric real values.")
+        if bool(xp.any(~xp.isfinite(sample_array))):
+            raise ValueError("samples must be finite.")
+
+        if weights is None:
+            weight_array = xp.ones(sample_array.shape, dtype=float)
+        else:
+            weight_values = weights.values if isinstance(weights, StochasticScalar) else weights
+            try:
+                weight_array = xp.asarray(weight_values, dtype=float)
+            except (TypeError, ValueError) as exc:
+                raise TypeError("weights must be a one-dimensional numeric sequence.") from exc
+
+            if weight_array.ndim != 1:
+                raise ValueError("weights must be one-dimensional.")
+            if weight_array.shape != sample_array.shape:
+                raise ValueError("weights must have the same length as samples.")
+            if bool(xp.any(~xp.isfinite(weight_array))):
+                raise ValueError("weights must be finite.")
+            if bool(xp.any(weight_array < 0)):
+                raise ValueError("weights must be non-negative.")
+
+        positive = weight_array > 0
+        if not bool(xp.any(positive)):
+            raise ValueError("weights must contain at least one positive value.")
+
+        sample_array = sample_array[positive]
+        weight_array = weight_array[positive]
+        order = xp.argsort(sample_array)
+        self._samples = sample_array[order]
+        normalized_weights = weight_array[order] / xp.sum(weight_array)
+        self._cumulative_weights = xp.cumsum(normalized_weights)
+        self._cumulative_weights[-1] = 1.0
+        super().__init__()
+
+    def _wrap_result(self, result: t.Any, argument: DistributionParameter) -> ReturnType:
+        """Preserve coupling from a stochastic CDF or inverse-CDF argument."""
+        if not isinstance(argument, StochasticScalar):
+            return scalar_or_array(result)
+
+        wrapped = StochasticScalar(result)
+        wrapped.coupled_variable_group.merge(argument.coupled_variable_group)
+        return wrapped
+
+    @override
+    def cdf(self, x: DistributionParameter) -> ReturnType:
+        """Compute the weighted empirical cumulative distribution function."""
+        values = xp.asarray(x.values if isinstance(x, StochasticScalar) else x)
+        indices = xp.searchsorted(self._samples, values, side="right")
+        cumulative = xp.concatenate((xp.zeros(1, dtype=float), self._cumulative_weights))
+        result = cumulative[indices]
+        result = xp.where(xp.isnan(values), xp.nan, result)
+        return self._wrap_result(result, x)
+
+    @override
+    def invcdf(self, u: DistributionParameter) -> ReturnType:
+        """Compute the generalized inverse empirical CDF."""
+        probabilities = xp.asarray(u.values if isinstance(u, StochasticScalar) else u)
+        invalid = (probabilities < 0) | (probabilities > 1) | xp.isnan(probabilities)
+        safe_probabilities = xp.clip(probabilities, 0.0, 1.0)
+        indices = xp.searchsorted(self._cumulative_weights, safe_probabilities, side="left")
+        quantiles = self._samples[indices].astype(float, copy=False)
+        result = xp.where(invalid, xp.nan, quantiles)
+        return self._wrap_result(result, u)
+
+    @override
+    def _generate(self, n_sims: int, rng: RandomGenerator) -> StochasticScalar:
+        """Resample observations with replacement using the empirical weights."""
+        if n_sims < 1:
+            raise ValueError(f"n_sims must be >= 1, got {n_sims}")
+
+        uniforms = xp.asarray(rng.uniform(size=n_sims))
+        indices = xp.searchsorted(self._cumulative_weights, uniforms, side="left")
+        return StochasticScalar(self._samples[indices])

--- a/src/pal/hyperexponential.py
+++ b/src/pal/hyperexponential.py
@@ -1,0 +1,256 @@
+"""Hyperexponential distribution.
+
+This module contains the finite-mixture hyperexponential distribution. It lives
+separately from :mod:`pal.distributions` because its component weights and rates
+are vector-valued parameters rather than single ``DistributionParameter`` values.
+The public class is exposed as ``pal.HyperExponential`` and
+``pal.distributions.HyperExponential`` by :mod:`pal`.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from ._compat import override
+from ._maths import scalar_or_array, xp
+from .distributions import DistributionBase, ReturnType
+from .stochastic_scalar import StochasticScalar
+from .types import DistributionParameter, RandomGenerator
+
+
+class HyperExponential(DistributionBase):
+    r"""Finite mixture of exponential distributions.
+
+    Let :math:`p_i \geq 0`, :math:`\sum_{i=1}^m p_i=1`, and
+    :math:`\lambda_i>0`. With location parameter :math:`\mu`, the density is
+
+    .. math::
+
+        f(x) = \sum_{i=1}^m p_i \lambda_i
+        \exp\left[-\lambda_i(x-\mu)\right], \qquad x>\mu,
+
+    and the cumulative distribution function is
+
+    .. math::
+
+        F(x) = \begin{cases}
+        0, & x \leq \mu, \\
+        1-\displaystyle\sum_{i=1}^m p_i
+        \exp\left[-\lambda_i(x-\mu)\right], & x>\mu.
+        \end{cases}
+
+    The first two moments are
+
+    .. math::
+
+        E[X] = \mu + \sum_{i=1}^m \frac{p_i}{\lambda_i},
+
+    .. math::
+
+        \operatorname{Var}(X) =
+        2\sum_{i=1}^m \frac{p_i}{\lambda_i^2}
+        - \left(\sum_{i=1}^m \frac{p_i}{\lambda_i}\right)^2.
+
+    A one-component hyperexponential distribution is an ordinary exponential
+    distribution. Mixtures with distinct rates have a decreasing hazard rate
+    and can represent substantially more heterogeneity than a single
+    exponential distribution.
+
+    ``weights`` and ``rates`` may contain ``StochasticScalar`` values. In that
+    case the parameter constraints are checked for every simulation and the
+    generated result is placed in the same coupled variable groups.
+
+    Parameters:
+        weights: Component probabilities :math:`p_i`. They must be non-negative
+            and sum to one.
+        rates: Positive component rates :math:`\lambda_i`.
+        loc: Location parameter :math:`\mu` (default 0).
+    """
+
+    def __init__(
+        self,
+        weights: t.Sequence[DistributionParameter],
+        rates: t.Sequence[DistributionParameter],
+        loc: DistributionParameter = 0.0,
+    ) -> None:
+        """Initialize a hyperexponential distribution.
+
+        Args:
+            weights: Mixture probabilities, one per component.
+            rates: Positive exponential rates, one per component.
+            loc: Location parameter.
+        """
+        if len(weights) == 0:
+            raise ValueError("weights and rates must contain at least one component.")
+        if len(weights) != len(rates):
+            raise ValueError("weights and rates must have the same number of components.")
+
+        self._weights = tuple(weights)
+        self._rates = tuple(rates)
+        super().__init__(loc=loc)
+        self._validated_component_parameters()
+
+    @classmethod
+    def from_scales(
+        cls,
+        weights: t.Sequence[DistributionParameter],
+        scales: t.Sequence[DistributionParameter],
+        loc: DistributionParameter = 0.0,
+    ) -> HyperExponential:
+        r"""Construct the distribution from exponential scale parameters.
+
+        PAL's :class:`pal.distributions.Exponential` uses the scale (mean)
+        parameterisation. This constructor accepts corresponding component
+        scales :math:`\theta_i=1/\lambda_i`.
+
+        Args:
+            weights: Mixture probabilities, one per component.
+            scales: Positive exponential scales, one per component.
+            loc: Location parameter.
+
+        Returns:
+            Hyperexponential distribution with rates equal to reciprocal scales.
+        """
+        rates = [t.cast(DistributionParameter, 1 / scale) for scale in scales]
+        return cls(weights=weights, rates=rates, loc=loc)
+
+    def _component_inputs(self) -> tuple[DistributionParameter, ...]:
+        """Return all component parameters in coupling order."""
+        return (*self._weights, *self._rates)
+
+    def _component_arrays(self) -> tuple[t.Any, t.Any]:
+        """Broadcast and stack component weights and rates on the active backend."""
+        values = [
+            xp.asarray(value.values if isinstance(value, StochasticScalar) else value)
+            for value in self._component_inputs()
+        ]
+        try:
+            broadcast = xp.broadcast_arrays(*values)
+        except ValueError as exc:
+            raise ValueError("All stochastic component parameters must have compatible simulation dimensions.") from exc
+
+        n_components = len(self._weights)
+        weights = xp.stack(broadcast[:n_components], axis=-1)
+        rates = xp.stack(broadcast[n_components:], axis=-1)
+        return weights, rates
+
+    def _validated_component_parameters(self) -> tuple[t.Any, t.Any]:
+        """Return component arrays after checking the admissible parameter region."""
+        weights, rates = self._component_arrays()
+        if bool(xp.any(~xp.isfinite(weights))):
+            raise ValueError("weights must be finite.")
+        if bool(xp.any(weights < 0)):
+            raise ValueError("weights must be non-negative.")
+        if bool(xp.any(~xp.isfinite(rates))) or bool(xp.any(rates <= 0)):
+            raise ValueError("rates must be finite and strictly positive.")
+
+        weight_sums = xp.sum(weights, axis=-1)
+        if not bool(xp.all(xp.isclose(weight_sums, 1.0, rtol=1e-10, atol=1e-12))):
+            raise ValueError("weights must sum to 1 for every simulation.")
+        return weights, rates
+
+    def _wrap_result(self, result: t.Any, argument: DistributionParameter) -> ReturnType:
+        """Preserve coupling from the argument and all stochastic parameters."""
+        candidates = (argument, self._params["loc"], *self._component_inputs())
+        stochastic_inputs = [value for value in candidates if isinstance(value, StochasticScalar)]
+        if not stochastic_inputs:
+            return scalar_or_array(result)
+
+        wrapped = StochasticScalar(result)
+        for value in stochastic_inputs:
+            wrapped.coupled_variable_group.merge(value.coupled_variable_group)
+        return wrapped
+
+    @staticmethod
+    def _mixture_cdf(values: t.Any, weights: t.Any, rates: t.Any) -> t.Any:
+        """Evaluate the zero-location CDF for non-negative values."""
+        component_cdfs = -xp.expm1(-values[..., None] * rates)
+        return xp.sum(weights * component_cdfs, axis=-1)
+
+    @override
+    def cdf(self, x: DistributionParameter) -> ReturnType:
+        """Compute the cumulative distribution function."""
+        weights, rates = self._validated_component_parameters()
+        values = xp.asarray(x.values if isinstance(x, StochasticScalar) else x)
+        loc = self._params["loc"]
+        loc_values = loc.values if isinstance(loc, StochasticScalar) else loc
+        shifted = values - loc_values
+        non_negative = xp.maximum(shifted, 0.0)
+        result = self._mixture_cdf(non_negative, weights, rates)
+        result = xp.where(shifted <= 0, 0.0, result)
+        return self._wrap_result(result, x)
+
+    @override
+    def invcdf(self, u: DistributionParameter) -> ReturnType:
+        """Compute the inverse CDF using monotone bisection.
+
+        A general hyperexponential quantile has no closed form. The upper
+        bracket follows from the slowest exponential component, so no heuristic
+        root-search bound is required.
+        """
+        weights, rates = self._validated_component_parameters()
+        probabilities = xp.asarray(u.values if isinstance(u, StochasticScalar) else u)
+        interior = (probabilities > 0) & (probabilities < 1)
+        safe_probabilities = xp.where(interior, probabilities, 0.5)
+
+        min_rate = xp.min(rates, axis=-1)
+        safe_probabilities, min_rate = xp.broadcast_arrays(safe_probabilities, min_rate)
+        lower = xp.zeros_like(safe_probabilities, dtype=float)
+        upper = -xp.log1p(-safe_probabilities) / min_rate
+
+        for _ in range(64):
+            midpoint = (lower + upper) / 2
+            midpoint_cdf = self._mixture_cdf(midpoint, weights, rates)
+            below = midpoint_cdf < safe_probabilities
+            lower = xp.where(below, midpoint, lower)
+            upper = xp.where(below, upper, midpoint)
+
+        quantile = (lower + upper) / 2
+        quantile = xp.where(
+            (probabilities < 0) | (probabilities > 1),
+            xp.nan,
+            xp.where(probabilities == 0, 0.0, xp.where(probabilities == 1, xp.inf, quantile)),
+        )
+
+        loc = self._params["loc"]
+        loc_values = loc.values if isinstance(loc, StochasticScalar) else loc
+        return self._wrap_result(quantile + loc_values, u)
+
+    @override
+    def generate(
+        self,
+        n_sims: int | None = None,
+        rng: RandomGenerator | None = None,
+    ) -> StochasticScalar:
+        """Generate samples and preserve component-parameter coupling."""
+        result = super().generate(n_sims=n_sims, rng=rng)
+        for value in self._component_inputs():
+            if isinstance(value, StochasticScalar):
+                result.coupled_variable_group.merge(value.coupled_variable_group)
+        return result
+
+    @override
+    def _generate(self, n_sims: int, rng: RandomGenerator) -> StochasticScalar:
+        """Generate directly by first drawing the mixture component."""
+        if n_sims < 1:
+            raise ValueError(f"n_sims must be >= 1, got {n_sims}")
+
+        weights, rates = self._validated_component_parameters()
+        n_components = len(self._weights)
+        if weights.ndim == 1:
+            weights = xp.broadcast_to(weights, (n_sims, n_components))
+            rates = xp.broadcast_to(rates, (n_sims, n_components))
+        elif weights.ndim != 2 or weights.shape[0] != n_sims:
+            raise ValueError("Stochastic component parameters must contain exactly n_sims values.")
+
+        component_uniforms = xp.asarray(rng.uniform(size=n_sims))
+        cumulative_weights = xp.cumsum(weights, axis=-1)
+        components = xp.sum(component_uniforms[:, None] > cumulative_weights, axis=-1).astype(int)
+        selected_rates = xp.take_along_axis(rates, components[:, None], axis=-1)[:, 0]
+
+        exponential_uniforms = xp.asarray(rng.uniform(size=n_sims))
+        samples = -xp.log1p(-exponential_uniforms) / selected_rates
+
+        loc = self._params["loc"]
+        loc_values = loc.values if isinstance(loc, StochasticScalar) else loc
+        return StochasticScalar(samples + loc_values)

--- a/tests/test_empirical.py
+++ b/tests/test_empirical.py
@@ -1,0 +1,130 @@
+"""Tests for the empirical distribution."""
+
+import math
+
+import pytest
+
+from pal import Empirical, distributions
+from pal.config import set_random_seed
+from pal.stochastic_scalar import StochasticScalar
+from tests._assertions import allclose
+
+
+def test_empirical_unweighted_cdf_and_inverse_cdf() -> None:
+    """The unweighted empirical CDF and generalized inverse are exact."""
+    dist = Empirical([3.0, 1.0, 2.0, 2.0])
+
+    assert dist.cdf(0.5) == 0.0
+    assert dist.cdf(1.0) == pytest.approx(0.25)
+    assert dist.cdf(2.0) == pytest.approx(0.75)
+    assert dist.cdf(10.0) == 1.0
+
+    probabilities = StochasticScalar([0.0, 0.1, 0.25, 0.250001, 0.75, 0.750001, 1.0])
+    expected = StochasticScalar([1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+    assert allclose(dist.invcdf(probabilities), expected)
+
+
+def test_empirical_weighted_cdf_and_inverse_cdf() -> None:
+    """Arbitrary observation weights are normalized internally."""
+    dist = Empirical(samples=[1.0, 2.0, 4.0], weights=[2.0, 6.0, 2.0])
+
+    assert dist.cdf(0.0) == 0.0
+    assert dist.cdf(1.0) == pytest.approx(0.2)
+    assert dist.cdf(2.0) == pytest.approx(0.8)
+    assert dist.cdf(4.0) == 1.0
+
+    probabilities = StochasticScalar([0.0, 0.2, 0.200001, 0.8, 0.800001, 1.0])
+    expected = StochasticScalar([1.0, 1.0, 2.0, 2.0, 4.0, 4.0])
+    assert allclose(dist.invcdf(probabilities), expected)
+
+
+def test_empirical_duplicate_samples_accumulate_probability() -> None:
+    """Repeated observations contribute their combined mass at one support value."""
+    dist = Empirical(samples=[1.0, 2.0, 2.0, 4.0], weights=[1.0, 2.0, 3.0, 4.0])
+
+    assert dist.cdf(1.5) == pytest.approx(0.1)
+    assert dist.cdf(2.0) == pytest.approx(0.6)
+    assert dist.invcdf(0.6) == 2.0
+    assert dist.invcdf(0.600001) == 4.0
+
+
+def test_empirical_zero_weight_observations_are_ignored() -> None:
+    """Zero-weight observations do not affect support or quantiles."""
+    dist = Empirical(samples=[-100.0, 1.0, 3.0, 100.0], weights=[0.0, 2.0, 2.0, 0.0])
+
+    assert dist.cdf(0.0) == 0.0
+    assert dist.invcdf(0.0) == 1.0
+    assert dist.invcdf(1.0) == 3.0
+
+
+def test_empirical_generation_reproduces_weighted_probabilities() -> None:
+    """Resampling reproduces the weighted empirical probabilities."""
+    set_random_seed(12345678910)
+    dist = Empirical(samples=[1.0, 4.0, 10.0], weights=[1.0, 3.0, 6.0])
+
+    sims = dist.generate(300_000)
+    expected_mean = 0.1 * 1.0 + 0.3 * 4.0 + 0.6 * 10.0
+    expected_second_moment = 0.1 * 1.0**2 + 0.3 * 4.0**2 + 0.6 * 10.0**2
+    expected_std = math.sqrt(expected_second_moment - expected_mean**2)
+
+    assert sims.mean() == pytest.approx(expected_mean, rel=5e-3)
+    assert sims.std() == pytest.approx(expected_std, rel=5e-3)
+
+
+def test_empirical_accepts_stochastic_scalar_as_observed_sample() -> None:
+    """A StochasticScalar can be reused as fixed empirical support."""
+    source = StochasticScalar([5.0, 1.0, 3.0, 7.0])
+    dist = Empirical(source)
+
+    assert dist.cdf(3.0) == pytest.approx(0.5)
+    assert dist.invcdf(0.75) == 5.0
+
+
+def test_empirical_cdf_and_inverse_preserve_argument_coupling() -> None:
+    """Vector CDF and inverse-CDF results remain coupled to their arguments."""
+    dist = Empirical(samples=[1.0, 2.0, 5.0], weights=[1.0, 2.0, 1.0])
+    values = StochasticScalar([0.0, 2.0, 10.0])
+    probabilities = StochasticScalar([0.1, 0.6, 0.9])
+
+    cdf_result = dist.cdf(values)
+    inverse_result = dist.invcdf(probabilities)
+
+    assert cdf_result.coupled_variable_group == values.coupled_variable_group
+    assert inverse_result.coupled_variable_group == probabilities.coupled_variable_group
+
+
+def test_empirical_invalid_probabilities_return_nan() -> None:
+    """Inverse-CDF probabilities outside the unit interval return NaN."""
+    dist = Empirical([1.0, 2.0, 3.0])
+
+    result = dist.invcdf(StochasticScalar([-0.1, 0.5, 1.1]))
+    assert math.isnan(float(result[0]))
+    assert result[1] == 2.0
+    assert math.isnan(float(result[2]))
+
+
+@pytest.mark.parametrize(
+    ("samples", "weights", "error_type"),
+    [
+        ([], None, ValueError),
+        ([[1.0, 2.0]], None, ValueError),
+        ([1.0, math.nan], None, ValueError),
+        ([1.0, math.inf], None, ValueError),
+        ([1.0, 2.0], [1.0], ValueError),
+        ([1.0, 2.0], [[1.0, 1.0]], ValueError),
+        ([1.0, 2.0], [-1.0, 2.0], ValueError),
+        ([1.0, 2.0], [0.0, 0.0], ValueError),
+        ([1.0, 2.0], [1.0, math.nan], ValueError),
+        (["a", "b"], None, TypeError),
+    ],
+)
+def test_empirical_rejects_invalid_inputs(samples: object, weights: object, error_type: type[Exception]) -> None:
+    """Invalid empirical samples and weights fail at construction."""
+    with pytest.raises(error_type):
+        Empirical(samples=samples, weights=weights)
+
+
+def test_empirical_is_exposed_in_distributions_namespace() -> None:
+    """The public distributions namespace and discrete registry expose the class."""
+    assert distributions.Empirical is Empirical
+    assert distributions.AVAILABLE_DISCRETE_DISTRIBUTIONS["empirical"] is Empirical

--- a/tests/test_empirical.py
+++ b/tests/test_empirical.py
@@ -80,6 +80,18 @@ def test_empirical_accepts_stochastic_scalar_as_observed_sample() -> None:
     assert dist.invcdf(0.75) == 5.0
 
 
+def test_empirical_generation_is_not_coupled_to_stochastic_input_data() -> None:
+    """Empirical support and weights are data, not stochastic parameters."""
+    source = StochasticScalar([1.0, 2.0, 3.0, 4.0])
+    weights = StochasticScalar([1.0, 2.0, 3.0, 4.0])
+    dist = Empirical(source, weights=weights)
+
+    sims = dist.generate(100)
+
+    assert sims.coupled_variable_group != source.coupled_variable_group
+    assert sims.coupled_variable_group != weights.coupled_variable_group
+
+
 def test_empirical_cdf_and_inverse_preserve_argument_coupling() -> None:
     """Vector CDF and inverse-CDF results remain coupled to their arguments."""
     dist = Empirical(samples=[1.0, 2.0, 5.0], weights=[1.0, 2.0, 1.0])

--- a/tests/test_hyperexponential.py
+++ b/tests/test_hyperexponential.py
@@ -19,7 +19,7 @@ def test_hyperexponential_cdf_and_inverse_cdf() -> None:
     dist = HyperExponential(weights=weights, rates=rates, loc=loc)
 
     assert dist.cdf(loc) == 0.0
-    expected = sum(weight * (1 - math.exp(-rate)) for weight, rate in zip(weights, rates, strict=True))
+    expected = sum(weight * (1 - math.exp(-rate)) for weight, rate in zip(weights, rates))
     assert dist.cdf(loc + 1) == pytest.approx(expected)
     assert dist.invcdf(0) == loc
     assert math.isinf(float(dist.invcdf(1)))
@@ -66,11 +66,9 @@ def test_hyperexponential_simulated_moments() -> None:
     dist = HyperExponential(weights=weights, rates=rates, loc=loc)
 
     sims = dist.generate(500_000)
-    centred_mean = sum(weight / rate for weight, rate in zip(weights, rates, strict=True))
+    centred_mean = sum(weight / rate for weight, rate in zip(weights, rates))
     expected_mean = loc + centred_mean
-    expected_variance = (
-        2 * sum(weight / rate**2 for weight, rate in zip(weights, rates, strict=True)) - centred_mean**2
-    )
+    expected_variance = 2 * sum(weight / rate**2 for weight, rate in zip(weights, rates)) - centred_mean**2
 
     assert sims.mean() == pytest.approx(expected_mean, rel=5e-3)
     assert sims.std() == pytest.approx(math.sqrt(expected_variance), rel=1e-2)
@@ -123,5 +121,5 @@ def test_hyperexponential_rejects_invalid_parameters(weights: list[float], rates
 
 def test_hyperexponential_is_exposed_in_distributions_namespace() -> None:
     """The public distributions namespace and name registry expose the class."""
-    assert getattr(distributions, "HyperExponential") is HyperExponential
+    assert distributions.__dict__["HyperExponential"] is HyperExponential
     assert distributions.AVAILABLE_CONTINUOUS_DISTRIBUTIONS["hyperexponential"] is HyperExponential

--- a/tests/test_hyperexponential.py
+++ b/tests/test_hyperexponential.py
@@ -2,10 +2,10 @@
 
 import math
 
+import numpy as np
 import pytest
 
 from pal import HyperExponential, distributions
-from pal._maths import xp as np
 from pal.config import set_random_seed
 from pal.stochastic_scalar import StochasticScalar
 from tests._assertions import allclose

--- a/tests/test_hyperexponential.py
+++ b/tests/test_hyperexponential.py
@@ -1,0 +1,127 @@
+"""Tests for the hyperexponential distribution."""
+
+import math
+
+import pytest
+
+from pal import HyperExponential, distributions
+from pal._maths import xp as np
+from pal.config import set_random_seed
+from pal.stochastic_scalar import StochasticScalar
+from tests._assertions import allclose
+
+
+def test_hyperexponential_cdf_and_inverse_cdf() -> None:
+    """CDF and numerical inverse CDF agree across the body and tail."""
+    weights = [0.25, 0.75]
+    rates = [1.0, 0.25]
+    loc = 2.0
+    dist = HyperExponential(weights=weights, rates=rates, loc=loc)
+
+    assert dist.cdf(loc) == 0.0
+    expected = sum(weight * (1 - math.exp(-rate)) for weight, rate in zip(weights, rates, strict=True))
+    assert dist.cdf(loc + 1) == pytest.approx(expected)
+    assert dist.invcdf(0) == loc
+    assert math.isinf(float(dist.invcdf(1)))
+
+    probabilities = StochasticScalar([0.001, 0.1, 0.5, 0.9, 0.999])
+    quantiles = dist.invcdf(probabilities)
+    assert allclose(dist.cdf(quantiles), probabilities, rtol=1e-11, atol=1e-12)
+
+
+def test_hyperexponential_reduces_to_exponential() -> None:
+    """A one-component mixture is the existing exponential distribution."""
+    rate = 0.4
+    loc = 3.0
+    hyperexponential = HyperExponential(weights=[1.0], rates=[rate], loc=loc)
+    exponential = distributions.Exponential(scale=1 / rate, loc=loc)
+    probabilities = StochasticScalar([0.01, 0.2, 0.5, 0.9, 0.999])
+
+    assert allclose(hyperexponential.invcdf(probabilities), exponential.invcdf(probabilities), rtol=1e-11)
+    assert allclose(
+        hyperexponential.cdf(hyperexponential.invcdf(probabilities)),
+        probabilities,
+        rtol=1e-11,
+        atol=1e-12,
+    )
+
+
+def test_hyperexponential_from_scales() -> None:
+    """The scale convenience constructor matches reciprocal rates."""
+    weights = [0.3, 0.7]
+    scales = [0.5, 4.0]
+    from_scales = HyperExponential.from_scales(weights=weights, scales=scales)
+    from_rates = HyperExponential(weights=weights, rates=[2.0, 0.25])
+    probabilities = StochasticScalar([0.05, 0.25, 0.75, 0.95])
+
+    assert allclose(from_scales.invcdf(probabilities), from_rates.invcdf(probabilities), rtol=1e-11)
+
+
+def test_hyperexponential_simulated_moments() -> None:
+    """Generated samples reproduce the analytical mean and variance."""
+    set_random_seed(12345678910)
+    weights = [0.2, 0.3, 0.5]
+    rates = [2.0, 0.5, 1 / 7]
+    loc = 10.0
+    dist = HyperExponential(weights=weights, rates=rates, loc=loc)
+
+    sims = dist.generate(500_000)
+    centred_mean = sum(weight / rate for weight, rate in zip(weights, rates, strict=True))
+    expected_mean = loc + centred_mean
+    expected_variance = (
+        2 * sum(weight / rate**2 for weight, rate in zip(weights, rates, strict=True)) - centred_mean**2
+    )
+
+    assert sims.mean() == pytest.approx(expected_mean, rel=5e-3)
+    assert sims.std() == pytest.approx(math.sqrt(expected_variance), rel=1e-2)
+
+
+def test_hyperexponential_stochastic_component_parameters_preserve_coupling() -> None:
+    """Scenario-varying mixture weights and rates are evaluated elementwise."""
+    probability = StochasticScalar([0.2, 0.4, 0.6])
+    rate = StochasticScalar([0.5, 1.0, 2.0])
+    dist = HyperExponential(weights=[probability, 1 - probability], rates=[rate, 3.0])
+
+    result = dist.cdf(1.0)
+    expected = probability * (1 - np.exp(-rate)) + (1 - probability) * (1 - np.exp(-3.0))
+
+    assert allclose(result, expected)
+    assert result.coupled_variable_group == probability.coupled_variable_group
+    assert result.coupled_variable_group == rate.coupled_variable_group
+
+
+def test_hyperexponential_stochastic_sampling_preserves_coupling() -> None:
+    """Sampling supports scenario-varying component parameters."""
+    set_random_seed(12345678910)
+    n_sims = 10_000
+    probability = distributions.Beta(2.0, 3.0).generate(n_sims)
+    rate = distributions.Gamma(2.0, 0.5).generate(n_sims)
+    dist = HyperExponential(weights=[probability, 1 - probability], rates=[rate, 3.0])
+
+    sims = dist.generate(n_sims)
+
+    assert sims.coupled_variable_group == probability.coupled_variable_group
+    assert sims.coupled_variable_group == rate.coupled_variable_group
+
+
+@pytest.mark.parametrize(
+    ("weights", "rates"),
+    [
+        ([], []),
+        ([0.5, 0.5], [1.0]),
+        ([-0.1, 1.1], [1.0, 2.0]),
+        ([0.4, 0.4], [1.0, 2.0]),
+        ([0.5, 0.5], [0.0, 2.0]),
+        ([0.5, 0.5], [1.0, math.inf]),
+    ],
+)
+def test_hyperexponential_rejects_invalid_parameters(weights: list[float], rates: list[float]) -> None:
+    """Invalid mixture definitions fail at construction."""
+    with pytest.raises(ValueError):
+        HyperExponential(weights=weights, rates=rates)
+
+
+def test_hyperexponential_is_exposed_in_distributions_namespace() -> None:
+    """The public distributions namespace and name registry expose the class."""
+    assert getattr(distributions, "HyperExponential") is HyperExponential
+    assert distributions.AVAILABLE_CONTINUOUS_DISTRIBUTIONS["hyperexponential"] is HyperExponential


### PR DESCRIPTION
Adds two univariate distributions to PAL.

### HyperExponential
- standard weights/rates parameterisation and a `from_scales` convenience constructor
- analytical CDF and robust bisection inverse CDF
- direct mixture sampling on CPU/GPU without routing generation through the numerical inverse
- support for scenario-varying `StochasticScalar` component weights/rates with coupling preservation
- analytical moment documentation and API docs
- numerical, moment, validation, coupling, and exponential-reduction tests

### Empirical
- `Empirical(samples, weights=None)` finite empirical distribution
- optional arbitrary non-negative observation weights, normalised internally
- exact weighted empirical CDF and generalized-inverse quantiles
- direct weighted resampling with replacement on CPU/GPU
- accepts an existing `StochasticScalar` as fixed empirical support
- zero-weight observations ignored, duplicates handled naturally
- validation, weighted-CDF/quantile, resampling, coupling, and edge-case tests

Both vector-valued distributions live in small separate modules and are exposed through the usual `pal` and `pal.distributions` namespaces and the appropriate named-distribution registries.