### PR TITLE
Add operational risk LDA tutorial

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -127,6 +127,7 @@ A small model, end to end
    tutorials/getting_started
    tutorials/distributions_guide
    tutorials/frequency_severity_modelling
+   tutorials/operational_risk_lda
    tutorials/coupling_groups_and_copulas
    tutorials/xol_reinsurance
    tutorials/reinstatement_pricing

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -10,6 +10,7 @@ Library (PAL) with worked examples and outputs.
 | [Getting Started](getting_started.md) | First steps — distributions, stochastic variables, basic arithmetic and configuration |
 | [Distributions Guide](distributions_guide.md) | Choosing and parameterising severity and frequency distributions |
 | [Frequency-Severity Modelling](frequency_severity_modelling.md) | Compound models, aggregate losses, occurrence maxima and derived statistics |
+| [Operational Risk LDA — Böcker & Klüppelberg (2005)](operational_risk_lda.md) | Pareto-Poisson operational risk, high-quantile OpVaR and the single-loss approximation |
 | [Coupling Groups, Copulas and Variable Reordering](coupling_groups_and_copulas.md) | Dependency structures, copula families, rank reordering and coupling groups |
 | [Pricing an Excess-of-Loss Reinsurance Program](xol_reinsurance.md) | XoL layers, towers, reinstatements, aggregate limits and net loss calculation |
 | [XoL Reinstatement Pricing — Mata (2000)](reinstatement_pricing.md) | Reproducing pure premiums and PH transform premiums with reinstatements |

--- a/docs/tutorials/operational_risk_lda.md
+++ b/docs/tutorials/operational_risk_lda.md
@@ -1,0 +1,284 @@
+# Operational Risk LDA — Böcker & Klüppelberg (2005)
+
+This tutorial implements the loss distribution approach (LDA) from the classic
+operational-risk paper:
+
+> Böcker, K. and Klüppelberg, C. (2005). "Operational VaR: a closed-form
+> approximation." *Risk*, 18(12), 90–93.
+
+The paper shows that, for a compound frequency-severity model with a
+heavy-tailed severity distribution, very high aggregate-loss quantiles can be
+approximated by a single severity quantile. This gives a useful benchmark for a
+Monte Carlo operational-risk model.
+
+The example below follows the paper's Pareto-Poisson construction. The frequency
+parameter used here is a transparent worked-example choice rather than an attempt
+to reproduce every numerical point in the paper's Figure 1.
+
+## 1. The loss distribution approach
+
+Let annual aggregate operational loss be
+
+```{math}
+S(t) = \sum_{i=1}^{N(t)} X_i,
+```
+
+where `N(t)` is the number of loss events up to time `t` and the `X_i` are
+independent severities. For a subexponential severity distribution with CDF
+`F`, Böcker and Klüppelberg obtain the first-order high-quantile approximation
+
+```{math}
+\operatorname{VaR}_t(\kappa)
+\sim
+F^{-1}\!\left(1 - \frac{1-\kappa}{\operatorname{E}[N(t)]}\right),
+\qquad \kappa \to 1.
+```
+
+The intuition is that an extreme annual loss is increasingly dominated by one
+exceptionally large event rather than by an unusually large sum of ordinary
+events. This is often called a **single-loss approximation**.
+
+For a Poisson process with annual intensity `lambda`,
+`E[N(t)] = lambda * t`.
+
+## 2. Pareto severity model
+
+The paper uses the Pareto Type II (Lomax) severity distribution
+
+```{math}
+F(x) = 1 - \left(1 + \frac{x}{\theta}\right)^{-\alpha},
+\qquad x > 0,
+```
+
+with shape `alpha > 0` and scale `theta > 0`. Substituting its inverse CDF into
+the single-loss approximation gives
+
+```{math}
+\operatorname{VaR}_t(\kappa)
+\approx
+\theta\left[
+\left(\frac{\lambda t}{1-\kappa}\right)^{1/\alpha} - 1
+\right].
+```
+
+PAL's `Pareto` class is Pareto Type I, with support starting at `scale`. A
+Pareto Type II random variable with the paper's parameterisation is therefore
+obtained by subtracting the scale:
+
+```{math}
+X = Y - \theta,
+\qquad Y \sim \operatorname{ParetoI}(\alpha, \theta).
+```
+
+## 3. Build the model in PAL
+
+We use an annual Poisson frequency of 10 and the paper's `theta = 1`. The
+heavier-tailed `alpha = 1.1` case is one of the shape parameters illustrated in
+the paper.
+
+```python
+import pandas as pd
+
+from pal.config import set_random_seed
+from pal.distributions import Pareto, Poisson
+from pal.frequency_severity import FrequencySeverityModel
+
+set_random_seed(42)
+
+MEAN_FREQUENCY = 10.0
+ALPHA = 1.1
+THETA = 1.0
+N_SIMS = 250_000
+```
+
+<!--pytest-codeblocks:cont-->
+
+```python
+model = FrequencySeverityModel(
+    freq_dist=Poisson(MEAN_FREQUENCY),
+    sev_dist=Pareto(shape=ALPHA, scale=THETA),
+)
+
+# Shifting Pareto Type I by theta gives the paper's Pareto Type II severity.
+events = model.generate(n_sims=N_SIMS) - THETA
+annual_loss = events.aggregate()
+```
+
+`events` contains the individual operational losses and `annual_loss` contains
+one total loss for each simulated year.
+
+## 4. The closed-form approximation
+
+The paper's Pareto-Poisson approximation can be written directly:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+def bocker_kluppelberg_var(
+    alpha: float,
+    theta: float,
+    mean_frequency: float,
+    confidence_level: float,
+    time_horizon: float = 1.0,
+) -> float:
+    """Return the Pareto-Poisson first-order operational VaR approximation."""
+    expected_events = mean_frequency * time_horizon
+    return theta * ((expected_events / (1.0 - confidence_level)) ** (1.0 / alpha) - 1.0)
+```
+
+At the 99.9% confidence level:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+approx_var_999 = bocker_kluppelberg_var(
+    alpha=ALPHA,
+    theta=THETA,
+    mean_frequency=MEAN_FREQUENCY,
+    confidence_level=0.999,
+)
+print(f"99.9% single-loss approximation: {approx_var_999:,.2f}")
+```
+
+```text
+99.9% single-loss approximation: 4,327.76
+```
+
+The result is deterministic: no simulation is needed to calculate the
+approximation once the frequency and severity parameters are known.
+
+## 5. Compare simulation with the paper's approximation
+
+Böcker and Klüppelberg compare their approximation with Monte Carlo values at
+very high confidence levels. We can make the same comparison using PAL. Note
+that `StochasticScalar.percentile()` uses percentile levels from 0 to 100,
+whereas the paper writes the confidence level as a probability between 0 and 1.
+
+<!--pytest-codeblocks:cont-->
+
+```python
+confidence_levels = [0.990, 0.995, 0.998, 0.999]
+simulated_var = annual_loss.percentile([100 * level for level in confidence_levels])
+
+rows = []
+for confidence_level, simulated in zip(confidence_levels, simulated_var):
+    approximation = bocker_kluppelberg_var(
+        alpha=ALPHA,
+        theta=THETA,
+        mean_frequency=MEAN_FREQUENCY,
+        confidence_level=confidence_level,
+    )
+    rows.append(
+        {
+            "confidence": confidence_level,
+            "simulated VaR": simulated,
+            "single-loss approximation": approximation,
+            "relative difference": (approximation / simulated) - 1.0,
+        }
+    )
+
+comparison = pd.DataFrame(rows).set_index("confidence")
+print(comparison)
+```
+
+The two columns should become close in the far tail, but they are not expected
+to be identical. The analytical result is a first-order asymptotic approximation
+as `kappa -> 1`, while the simulated quantile also has Monte Carlo error. For a
+production capital calculation, the simulation count should be chosen to give
+adequate precision at the target percentile.
+
+## 6. Why the tail index matters
+
+The approximation makes the impact of the Pareto tail index particularly clear.
+Keeping frequency and scale fixed, compare the two shape parameters used in the
+paper's Figure 1:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+shape_comparison = pd.DataFrame(
+    {
+        "alpha": [1.5, 1.1],
+        "99.9% approximate VaR": [
+            bocker_kluppelberg_var(1.5, THETA, MEAN_FREQUENCY, 0.999),
+            bocker_kluppelberg_var(1.1, THETA, MEAN_FREQUENCY, 0.999),
+        ],
+    }
+).set_index("alpha")
+print(shape_comparison)
+```
+
+| alpha | 99.9% approximate VaR |
+|------:|-----------------------:|
+| 1.5 | 463.16 |
+| 1.1 | 4,327.76 |
+
+A relatively small change in the tail index has an enormous effect on extreme
+capital. This is one reason severity-tail selection and parameter uncertainty
+matter so much in operational-risk models.
+
+## 7. Time scaling
+
+For the Pareto model, the leading term of the approximation implies the
+`alpha`-root-of-time rule derived in the paper:
+
+```{math}
+\frac{\operatorname{VaR}_t(\kappa)}
+     {\operatorname{VaR}_1(\kappa)}
+\sim t^{1/\alpha},
+\qquad \kappa \to 1.
+```
+
+This differs from the square-root-of-time rule associated with Gaussian risks.
+We can see the scaling directly from the closed form:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+one_year = bocker_kluppelberg_var(ALPHA, THETA, MEAN_FREQUENCY, 0.999)
+scaling_rows = []
+for years in [1, 2, 5]:
+    scaled_var = bocker_kluppelberg_var(
+        ALPHA,
+        THETA,
+        MEAN_FREQUENCY,
+        0.999,
+        time_horizon=float(years),
+    )
+    scaling_rows.append(
+        {
+            "years": years,
+            "closed-form VaR ratio": scaled_var / one_year,
+            "alpha-root rule": years ** (1.0 / ALPHA),
+        }
+    )
+
+scaling = pd.DataFrame(scaling_rows).set_index("years")
+print(scaling)
+```
+
+The ratios are not exactly equal at a finite confidence level because the
+Pareto-II quantile contains the `-1` location term. They converge to the
+`alpha`-root rule deeper in the tail.
+
+## 8. What this example does — and does not — show
+
+This example is deliberately stylised. It demonstrates three useful ideas:
+
+- operational risk fits naturally into PAL's frequency-severity framework;
+- heavy-tailed aggregate capital can be dominated by the severity tail; and
+- the Böcker-Klüppelberg approximation provides an independent analytical
+  benchmark for a Monte Carlo result.
+
+A practical operational-risk model may also need multiple risk cells,
+reporting thresholds or truncation, body-tail splicing, non-Poisson frequency,
+parameter uncertainty, scenario information and dependence between cells. The
+single-loss approximation remains valuable as a diagnostic even when the full
+model is more complicated.
+
+## References
+
+- Böcker, K. and Klüppelberg, C. (2005). "Operational VaR: a closed-form
+  approximation." *Risk*, 18(12), 90–93.
+- Embrechts, P., Klüppelberg, C. and Mikosch, T. (1997). *Modelling Extremal
+  Events for Insurance and Finance*. Springer.

--- a/examples/example_operational_risk_lda.py
+++ b/examples/example_operational_risk_lda.py
@@ -1,0 +1,100 @@
+"""Operational-risk LDA following Böcker and Klüppelberg (2005).
+
+Builds a Pareto-Poisson loss distribution model, simulates annual operational
+losses, and compares high aggregate-loss quantiles with the paper's closed-form
+single-loss approximation.
+"""
+
+import pandas as pd
+
+from pal.config import set_random_seed
+from pal.distributions import Pareto, Poisson
+from pal.frequency_severity import FrequencySeverityModel
+
+MEAN_FREQUENCY = 10.0
+ALPHA = 1.1
+THETA = 1.0
+N_SIMS = 250_000
+CONFIDENCE_LEVELS = [0.990, 0.995, 0.998, 0.999]
+
+
+def bocker_kluppelberg_var(
+    alpha: float,
+    theta: float,
+    mean_frequency: float,
+    confidence_level: float,
+    time_horizon: float = 1.0,
+) -> float:
+    """Return the Pareto-Poisson first-order operational VaR approximation."""
+    expected_events = mean_frequency * time_horizon
+    return theta * ((expected_events / (1.0 - confidence_level)) ** (1.0 / alpha) - 1.0)
+
+
+set_random_seed(42)
+
+model = FrequencySeverityModel(
+    freq_dist=Poisson(MEAN_FREQUENCY),
+    sev_dist=Pareto(shape=ALPHA, scale=THETA),
+)
+
+# PAL's Pareto is Type I. Subtracting theta gives the paper's Pareto Type II severity.
+events = model.generate(n_sims=N_SIMS) - THETA
+annual_loss = events.aggregate()
+
+simulated_var = annual_loss.percentile([100 * level for level in CONFIDENCE_LEVELS])
+rows = []
+for confidence_level, simulated in zip(CONFIDENCE_LEVELS, simulated_var):
+    approximation = bocker_kluppelberg_var(
+        alpha=ALPHA,
+        theta=THETA,
+        mean_frequency=MEAN_FREQUENCY,
+        confidence_level=confidence_level,
+    )
+    rows.append(
+        {
+            "confidence": confidence_level,
+            "simulated VaR": simulated,
+            "single-loss approximation": approximation,
+            "relative difference": (approximation / simulated) - 1.0,
+        }
+    )
+
+comparison = pd.DataFrame(rows).set_index("confidence")
+print("Böcker-Klüppelberg Pareto-Poisson operational VaR")
+print("=" * 58)
+print(comparison)
+
+print("\nTail-index sensitivity at 99.9%")
+print("=" * 35)
+shape_comparison = pd.DataFrame(
+    {
+        "alpha": [1.5, 1.1],
+        "99.9% approximate VaR": [
+            bocker_kluppelberg_var(1.5, THETA, MEAN_FREQUENCY, 0.999),
+            bocker_kluppelberg_var(1.1, THETA, MEAN_FREQUENCY, 0.999),
+        ],
+    }
+).set_index("alpha")
+print(shape_comparison)
+
+print("\nPareto alpha-root-of-time scaling at 99.9%")
+print("=" * 46)
+one_year = bocker_kluppelberg_var(ALPHA, THETA, MEAN_FREQUENCY, 0.999)
+scaling_rows = []
+for years in [1, 2, 5]:
+    scaled_var = bocker_kluppelberg_var(
+        ALPHA,
+        THETA,
+        MEAN_FREQUENCY,
+        0.999,
+        time_horizon=float(years),
+    )
+    scaling_rows.append(
+        {
+            "years": years,
+            "closed-form VaR ratio": scaled_var / one_year,
+            "alpha-root rule": years ** (1.0 / ALPHA),
+        }
+    )
+
+print(pd.DataFrame(scaling_rows).set_index("years"))

--- a/tests/test_bocker_kluppelberg_operational_risk.py
+++ b/tests/test_bocker_kluppelberg_operational_risk.py
@@ -1,0 +1,64 @@
+"""Tests for the Böcker-Klüppelberg (2005) operational-risk example."""
+
+import pytest
+
+from pal.config import set_random_seed
+from pal.distributions import Pareto, Poisson
+from pal.frequency_severity import FrequencySeverityModel
+
+
+def _bocker_kluppelberg_var(
+    alpha: float,
+    theta: float,
+    mean_frequency: float,
+    confidence_level: float,
+    time_horizon: float = 1.0,
+) -> float:
+    expected_events = mean_frequency * time_horizon
+    return theta * ((expected_events / (1.0 - confidence_level)) ** (1.0 / alpha) - 1.0)
+
+
+def test_shifted_pal_pareto_matches_paper_pareto_type_ii():
+    alpha = 1.5
+    theta = 2.0
+    loss = 7.0
+
+    pal_cdf = Pareto(shape=alpha, scale=theta).cdf(loss + theta)
+    paper_cdf = 1.0 - (1.0 + loss / theta) ** (-alpha)
+
+    assert pal_cdf == pytest.approx(paper_cdf)
+
+
+def test_closed_form_var_matches_adjusted_severity_quantile():
+    alpha = 1.1
+    theta = 1.0
+    mean_frequency = 10.0
+    confidence_level = 0.999
+    adjusted_probability = 1.0 - (1.0 - confidence_level) / mean_frequency
+
+    severity_quantile = Pareto(shape=alpha, scale=theta).invcdf(adjusted_probability) - theta
+    approximation = _bocker_kluppelberg_var(alpha, theta, mean_frequency, confidence_level)
+
+    assert severity_quantile == pytest.approx(approximation)
+    assert approximation == pytest.approx(4327.761281083053)
+
+
+def test_simulated_pareto_poisson_high_quantile_is_close_to_single_loss_approximation():
+    alpha = 1.1
+    theta = 1.0
+    mean_frequency = 10.0
+    confidence_level = 0.998
+
+    set_random_seed(42)
+    model = FrequencySeverityModel(
+        freq_dist=Poisson(mean_frequency),
+        sev_dist=Pareto(shape=alpha, scale=theta),
+    )
+    annual_loss = (model.generate(n_sims=200_000) - theta).aggregate()
+
+    simulated_var = annual_loss.percentile(100.0 * confidence_level)
+    approximation = _bocker_kluppelberg_var(alpha, theta, mean_frequency, confidence_level)
+
+    # The paper's result is first-order as confidence approaches one; the Monte Carlo
+    # check is intentionally looser than the exact parameterisation tests above.
+    assert simulated_var == pytest.approx(approximation, rel=0.20)


### PR DESCRIPTION
## Summary

- add a worked operational-risk LDA tutorial based on Böcker & Klüppelberg (2005)
- model Poisson frequency with Pareto-II/Lomax severity using PAL's frequency-severity framework
- compare simulated high-quantile OpVaR with the paper's closed-form single-loss approximation
- illustrate tail-index sensitivity and the Pareto alpha-root-of-time rule
- add a runnable example and regression tests for the parameterisation and high-quantile approximation
- add the tutorial to the documentation navigation

## Reference

Böcker, K. and Klüppelberg, C. (2005). "Operational VaR: a closed-form approximation." Risk, 18(12), 90–93.