### PR TITLE
Remove duplicate generated API pages

### DIFF
--- a/docs/source/api/pal.config.rst
+++ b/docs/source/api/pal.config.rst
@@ -1,7 +1,0 @@
-pal.config module
-=================
-
-.. automodule:: pal.config
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/docs/source/api/pal.contracts.rst
+++ b/docs/source/api/pal.contracts.rst
@@ -1,7 +1,0 @@
-pal.contracts module
-====================
-
-.. automodule:: pal.contracts
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/docs/source/api/pal.copulas.rst
+++ b/docs/source/api/pal.copulas.rst
@@ -1,6 +1,0 @@
-:orphan:
-
-pal.copulas module
-==================
-
-The copula reference is organised by concrete copula on :doc:`copulas`.

--- a/docs/source/api/pal.couplings.rst
+++ b/docs/source/api/pal.couplings.rst
@@ -1,7 +1,0 @@
-pal.couplings module
-====================
-
-.. automodule:: pal.couplings
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/docs/source/api/pal.distributions.rst
+++ b/docs/source/api/pal.distributions.rst
@@ -1,6 +1,0 @@
-:orphan:
-
-pal.distributions module
-========================
-
-The distribution reference is organised by concrete distribution on :doc:`distributions`.

--- a/docs/source/api/pal.frequency_severity.rst
+++ b/docs/source/api/pal.frequency_severity.rst
@@ -1,7 +1,0 @@
-pal.frequency\_severity module
-==============================
-
-.. automodule:: pal.frequency_severity
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/docs/source/api/pal.maths.rst
+++ b/docs/source/api/pal.maths.rst
@@ -1,7 +1,0 @@
-pal.maths module
-================
-
-.. automodule:: pal.maths
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/docs/source/api/pal.stats.rst
+++ b/docs/source/api/pal.stats.rst
@@ -1,7 +1,0 @@
-pal.stats module
-================
-
-.. automodule:: pal.stats
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/docs/source/api/pal.stochastic_scalar.rst
+++ b/docs/source/api/pal.stochastic_scalar.rst
@@ -1,7 +1,0 @@
-pal.stochastic\_scalar module
-=============================
-
-.. automodule:: pal.stochastic_scalar
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/docs/source/api/pal.types.rst
+++ b/docs/source/api/pal.types.rst
@@ -1,7 +1,0 @@
-pal.types module
-================
-
-.. automodule:: pal.types
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/docs/source/api/pal.variables.rst
+++ b/docs/source/api/pal.variables.rst
@@ -1,7 +1,0 @@
-pal.variables module
-====================
-
-.. automodule:: pal.variables
-   :members:
-   :show-inheritance:
-   :undoc-members:


### PR DESCRIPTION
## Summary

- remove stale `sphinx-apidoc`-style `pal.*.rst` module pages from `docs/source/api`
- retain the curated topic API pages (`variables.rst`, `stochastic_scalar.rst`, etc.)
- retain `pal.rst`, which is now just an orphan redirect to the curated API index

These stale pages documented the same modules a second time, causing classes such as `ProteusVariable` and `StochasticScalar` to appear twice in the generated API documentation.

## Scope

Documentation-only cleanup; no Python code changes.