### PR TITLE
Organize advanced tutorials under Examples

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -128,6 +128,12 @@ A small model, end to end
    tutorials/distributions_guide
    tutorials/frequency_severity_modelling
    tutorials/coupling_groups_and_copulas
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Examples
+   :hidden:
+
    tutorials/xol_reinsurance
    tutorials/property_exposure_rating
    tutorials/reinstatement_pricing


### PR DESCRIPTION
## Summary

- add an **Examples** section to the documentation navigation
- keep Getting Started, Distributions, Frequency-Severity Modelling, and Coupling Groups/Copulas under **Tutorials**
- move the applied XoL, property exposure rating, reinstatement pricing, and risk measures/capital allocation pages under **Examples**
- leave the underlying documentation paths unchanged so existing links continue to work

This is a navigation-only change in `docs/source/index.rst`.