### PR TITLE
Restore property exposure rating example

### DIFF
--- a/docs/source/tutorials/property_exposure_rating.md
+++ b/docs/source/tutorials/property_exposure_rating.md
@@ -1,0 +1,3 @@
+:::{include} ../../tutorials/property_exposure_rating.md
+:relative-images:
+:::


### PR DESCRIPTION
## Summary

- restore the missing Sphinx source wrapper for the Property Reinsurance Exposure Rating with MBBEFD example
- keep the existing tutorial content in `docs/tutorials/property_exposure_rating.md`
- make the existing `tutorials/property_exposure_rating` navigation entry resolve again under **Examples**

The underlying tutorial URL and content remain unchanged.