### PR TITLE
Make PAL easier for AI tools to use and develop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,16 @@
+# GitHub Copilot Instructions for PAL
+
+Before changing code, read the repository root `AGENTS.md` and any more-specific `AGENTS.md` in the directory being modified.
+
+Key expectations:
+
+- Treat `pyproject.toml` as authoritative for Python support, Ruff configuration and dependencies.
+- Treat `Makefile` and CI workflows as authoritative for validation commands.
+- Preserve PAL's public API and stochastic/coupling semantics unless the task explicitly changes them.
+- Read `docs/structure.md` before architectural or type-system changes.
+- For numerical code, add independent mathematical/reference validation where practical; do not rely only on implementation round trips.
+- For backend-sensitive code, preserve CPU/GPU semantics and avoid unnecessary host/device transfers.
+- For public APIs and documentation, use actuarial/statistical user language rather than unnecessary backend implementation terminology.
+- Run focused checks while iterating and the full relevant static-analysis/test suite before finishing.
+
+Do not duplicate configuration values in comments or instructions when the authoritative project configuration can be referenced directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ PAL uses standard Python packaging and also provides CPU/GPU devcontainers.
 
 A fresh environment can be prepared with:
 
+<!--pytest-codeblocks:skip-->
+
 ```bash
 pip install -e ".[test,dev,docs]"
 ```
@@ -49,6 +51,8 @@ When the `pal-devcontainer` container is already running, commands may be run th
 
 Prefer the narrowest useful check while iterating, then run the full relevant checks before finishing.
 
+<!--pytest-codeblocks:skip-->
+
 ```bash
 make lint
 make format-check
@@ -59,6 +63,8 @@ make check
 ```
 
 Run focused tests with `pytest path/to/test.py` or a specific test node. Documentation examples are executable and should remain valid.
+
+For documentation, remember that `pytest-codeblocks` treats fenced code blocks as independent by default. Use `<!--pytest-codeblocks:cont-->` before a block that intentionally depends on state created by an earlier block. Use `<!--pytest-codeblocks:skip-->` for illustrative shell commands or examples that should not execute in CI; do not use skips merely to hide a broken executable example. See `docs/AGENTS.md` for the documentation-specific rule.
 
 For GPU changes, also validate the GPU workflow or equivalent CUDA tests. CPU success alone is not sufficient for code that changes backend-sensitive behaviour.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# PAL Agent Guide
+
+This is the canonical repository-level guidance for coding agents working on the Proteus Actuarial Library (PAL).
+Tool-specific instruction files should point here rather than duplicate these rules.
+
+## What PAL Is
+
+PAL is a Python library for simulation-based actuarial and financial modelling. It provides stochastic variables, probability distributions, copulas, frequency-severity models, reinsurance contracts, risk measures and optional CuPy GPU acceleration.
+
+The installed package is `pal`; the PyPI distribution is `proteusllp-actuarial-library`.
+
+## Sources of Truth
+
+When instructions disagree, use these sources in this order:
+
+1. `pyproject.toml` for supported Python versions, dependencies, Ruff configuration and package metadata.
+2. `Makefile` and CI workflows for the commands that must pass.
+3. This file and any more-specific nested `AGENTS.md` for architectural and behavioural rules.
+4. `STYLE_GUIDE.md`, `docs/structure.md` and `docs/development.md` for additional explanation.
+
+Do not copy configuration values into new guidance when they can be referenced from the authoritative configuration instead.
+
+## Repository Map
+
+- `src/pal/`: library implementation. Read `src/pal/AGENTS.md` before changing library code.
+- `tests/`: automated tests. Read `tests/AGENTS.md` before adding or changing tests.
+- `docs/`: Sphinx documentation and tutorials. Read `docs/AGENTS.md` before changing documentation.
+- `examples/`: executable end-to-end examples.
+- `.github/workflows/`: CPU, GPU and other CI workflows.
+- `pyproject.toml`: package, dependency and static-analysis configuration.
+- `Makefile`: canonical local development commands.
+- `docs/structure.md`: type-system architecture and dependency direction.
+
+## Development Environment
+
+PAL uses standard Python packaging and also provides CPU/GPU devcontainers.
+
+A fresh environment can be prepared with:
+
+```bash
+pip install -e ".[test,dev,docs]"
+```
+
+For GPU work, install the `gpu` extra in a CUDA-capable environment.
+
+When the `pal-devcontainer` container is already running, commands may be run through `docker exec pal-devcontainer ...`. Do not assume that container exists in cloud or CI environments.
+
+## Validation
+
+Prefer the narrowest useful check while iterating, then run the full relevant checks before finishing.
+
+```bash
+make lint
+make format-check
+make typecheck
+make test-fast
+make static-analysis
+make check
+```
+
+Run focused tests with `pytest path/to/test.py` or a specific test node. Documentation examples are executable and should remain valid.
+
+For GPU changes, also validate the GPU workflow or equivalent CUDA tests. CPU success alone is not sufficient for code that changes backend-sensitive behaviour.
+
+## Definition of Done
+
+A change is complete when:
+
+- behaviour is covered by tests appropriate to the risk of the change;
+- public API changes have accurate user-facing docstrings and documentation;
+- static analysis and relevant tests pass;
+- CPU and GPU semantics remain consistent where the feature supports both;
+- numerical changes are checked against an independent theoretical or trusted reference where practical;
+- no unrelated refactoring, compatibility break or documentation churn is introduced.
+
+## General Rules
+
+- Preserve backwards compatibility unless the task explicitly changes the public API.
+- Prefer small, focused changes over broad rewrites.
+- Do not leave comments describing deleted or superseded code.
+- Keep imports at module scope unless there is a documented architectural reason not to.
+- Use type annotations for public interfaces; do not duplicate type information in docstrings.
+- Comments should explain non-obvious reasons, numerical choices or domain rules rather than narrate the code.
+- Never commit secrets or generated local environment state.
+
+## Before Architectural Changes
+
+Read `docs/structure.md`. In particular, PAL's protocol/type layer must remain independent of concrete implementations, and dependencies should continue to flow from lower to higher architectural layers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,93 +1,11 @@
 # Claude Development Guide
 
-This file contains project-specific information to help Claude work effectively with this codebase.
+The canonical development instructions for this repository are in [`AGENTS.md`](./AGENTS.md).
 
-## Development Environment
+Before making changes:
 
-This project uses Docker for consistent development environments.
+1. Read the root `AGENTS.md`.
+2. Read the nearest nested `AGENTS.md` for each area you modify (`src/pal/`, `tests/` or `docs/`).
+3. Follow `pyproject.toml`, `Makefile` and CI workflows when configuration or commands differ from prose documentation.
 
-### Command Execution Guidelines
-
-**Run INSIDE the Docker container (`pal-devcontainer`):**
-- All `make` commands (lint, test, typecheck, etc.)
-- Python commands
-- Package builds
-
-**Run on the HOST machine:**
-- Git commands (`git add`, `git commit`, `git push`, etc.)
-- GitHub CLI (`gh` commands for issues, PRs, etc.)
-- File editing (though this works in both environments)
-
-### Docker Commands
-
-The container name is configured in `.devcontainer/devcontainer.json` as `pal-devcontainer`:
-
-<!--pytest.mark.skip-->
-
-```bash
-# All development commands (run inside container):
-# Lint code
-docker exec pal-devcontainer make lint
-
-# Auto-fix lint issues
-docker exec pal-devcontainer make lint-fix
-
-# Run tests
-docker exec pal-devcontainer make test
-
-# Type checking
-docker exec pal-devcontainer make typecheck
-```
-
-### Python Execution
-
-<!--pytest.mark.skip-->
-
-```bash
-# Run Python scripts
-docker exec pal-devcontainer python script.py
-
-# Run examples
-docker exec pal-devcontainer python examples/example_catastrophes.py
-```
-
-<!--pytest.mark.skip-->
-
-### Finding Your Container
-```bash
-# List running containers
-docker ps
-
-# Filter by the devcontainer name
-docker ps --filter name=pal-devcontainer
-```
-
-## Code Style
-
-**IMPORTANT**:
-- Do not add cruft comments like "# mean() removed - use numpy.mean() instead". When removing code, just remove it cleanly without leaving placeholder comments.
-- **No nested imports** - Always import modules at the top of the file, not inside functions. Nested imports hide import errors and delay them until runtime instead of catching them at load time.
-
-**See [STYLE_GUIDE.md](./STYLE_GUIDE.md) for all coding standards including:**
-- Line length (88 characters max) - IMPORTANT: Never exceed 88 characters
-- Type annotations
-- Comments (explain WHY, not WHAT)
-- Docstring format
-- Import ordering
-- No trailing whitespace at end of lines
-- No unnecessary blank lines
-
-### Linting Workflow
-1. Run: `docker exec pal-devcontainer make lint`
-2. For auto-fixable errors: `docker exec pal-devcontainer make lint-fix`
-3. Manually fix remaining errors following [STYLE_GUIDE.md](./STYLE_GUIDE.md)
-4. **All lint errors must be fixed** (no warnings allowed in CI)
-
-## Project Structure
-
-- `pal/` - Main library code
-- `tests/` - Test suite
-- `examples/` - Usage examples
-- `pyproject.toml` - Project configuration including ruff lint rules
-- `STYLE_GUIDE.md` - **All coding standards and examples**
-- `docs/structure.md` - **Type system architecture and design principles**
+This file is intentionally small so that Claude-specific guidance cannot drift from the instructions used by other coding agents.

--- a/README.md
+++ b/README.md
@@ -78,10 +78,19 @@ pip install proteusllp-actuarial-library[gpu]
 
 **[Read the full documentation on Read the Docs](https://proteusllp-actuarial-library.readthedocs.io/)**
 
-
 - [Usage Guide](docs/usage.md) - Comprehensive examples and API documentation
 - [Development Guide](docs/development.md) - Setting up the development environment and running tests
 - [Examples](examples/) - Example scripts showing how to use the library
+
+## AI and coding assistants
+
+PAL provides dedicated entry points for AI tools as well as human-readable documentation:
+
+- [PAL quick reference for coding assistants](docs/source/ai_assistants.md) maps common modelling intentions to the public Python API.
+- [AGENTS.md](AGENTS.md) contains canonical repository instructions for coding agents, with more-specific guidance under `src/pal/`, `tests/` and `docs/`.
+- The documentation build publishes `llms.txt` and `llms-full.txt` at the documentation root for model-friendly retrieval.
+
+AI-generated PAL code should prefer documented public APIs and inspect signatures/docstrings rather than guessing parameterisations or relying on internal helpers.
 
 ## Project Status
 
@@ -103,4 +112,3 @@ Please log issues on our github [page](https://github.com/ProteusLLP/proteusllp-
 You are welcome to contribute pull requests. Please see the [Contributer License Agreement](./CLA.md)
 
 📚 **[Development Guide](docs/development.md)** - Get started with development setup and testing
-

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -3,10 +3,12 @@
 
 This document outlines the coding standards and style guidelines for the Proteus Actuarial Library.
 
+Configuration in `pyproject.toml` is authoritative where a tool setting or supported Python version is concerned.
+
 ## Code Style
 
-- **Line Length**: 120 characters (following Black's default)
-- **Python Version**: 3.11+
+- **Line Length**: 120 characters, as configured in `pyproject.toml`
+- **Python Version**: support the versions declared by `requires-python` and the project classifiers in `pyproject.toml`
 - **Import Sorting**: Automatic via ruff (isort rules)
 - **Code Formatting**: Automatic via ruff formatter
 - **Whitespace**: No trailing whitespace at end of lines
@@ -80,7 +82,7 @@ def calculate_premium(base_amount: float, rate: float) -> float:
 ## Comments
 
 - **Purpose**: Comments should explain WHY, not WHAT the code does
-- **Line Length**: Must not exceed 120 characters per line
+- **Line Length**: Must not exceed the Ruff line length configured in `pyproject.toml`
 - **Quality**: The code itself shows what it does - comments that repeat this are redundant noise
 - **Good comments explain**:
   - Business logic and domain-specific rules
@@ -104,8 +106,8 @@ for item in reversed(items):
 ## Docstrings
 
 - **Style**: Google-style docstrings
-- **Required**: All public modules, classes, functions, and methods
-- **Required**: Test functions should have docstrings explaining what they test
+- **Required**: Public modules, classes, functions, and methods according to the Ruff configuration
+- **Tests**: Use a test docstring when it adds useful intent; test-function docstrings are not required by lint
 - **No Types**: Do not include type information in docstrings (use type hints instead)
 
 ### Function/Method Docstrings
@@ -147,12 +149,15 @@ class ActuarialModel:
 
 ### Test Docstrings
 
+Use test names as the primary description. Add a docstring when the reason for a test or its numerical reference is not obvious from the name and assertions.
+
 ```python
 def test_premium_calculation_with_zero_rate():
-    """Test that premium calculation returns zero when rate is zero."""
+    """Zero premium rate must produce zero premium."""
+
 
 def test_policy_validation_rejects_expired_policies():
-    """Test that policy validation properly rejects expired policies."""
+    """Expired policies are rejected before claims are processed."""
 ```
 
 ## Security
@@ -166,9 +171,11 @@ def test_policy_validation_rejects_expired_policies():
 The following tools are configured and must pass in CI:
 
 - **ruff**: Linting, formatting, import sorting, docstring validation
-- **mypy**: Type checking with strict mode
+- **pyright**: Type checking
 - **bandit**: Security vulnerability scanning
 - **vulture**: Dead code detection
+
+The `Makefile` is the canonical interface for running these checks.
 
 ## VS Code Configuration
 
@@ -178,15 +185,20 @@ Install these extensions for consistent development experience:
 - **Pylance** (`ms-python.pylance`) - Type checking and IntelliSense
 - **Python** (`ms-python.python`) - Core Python support
 
-The project includes `.vscode/settings.json` with tool configurations that match CI.
+The project includes VS Code/devcontainer configuration intended to match CI.
 
 ## Enforcement
 
-All static analysis checks must pass before code can be merged. The CI pipeline will:
+All configured static analysis checks must pass before code can be merged. Use the Makefile rather than maintaining a separate list of direct tool commands:
 
-1. Run ruff for linting and formatting checks
-2. Run mypy for type checking
-3. Run bandit for security scanning
-4. Run vulture for dead code detection
+```bash
+make static-analysis
+```
 
-Use `pdm run` commands locally to ensure compliance before pushing.
+Before completing a change, run the full relevant validation, normally:
+
+```bash
+make check
+```
+
+For backend-sensitive changes, also run the relevant GPU validation described in the repository agent guidance and CI workflows.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -19,7 +19,9 @@ Avoid exposing internal implementation language in user-facing descriptions when
 
 Prefer small canonical examples that demonstrate one concept clearly. Documentation code should use the public API a normal PAL user should copy.
 
-Executable code blocks should remain compatible with `pytest-codeblocks`. Mark code as skipped only when execution genuinely requires external resources, interactive display, unavailable hardware or another documented reason.
+Executable code blocks should remain compatible with `pytest-codeblocks`. Each fenced block is executed independently by default. If a block deliberately relies on imports, variables or other state established by an earlier block, place `<!--pytest-codeblocks:cont-->` immediately before it so the sequence is tested in one shared namespace.
+
+Use `<!--pytest-codeblocks:skip-->` only when a block is intentionally non-executable in the test environment, such as illustrative development shell commands, external-resource examples, interactive display or unavailable hardware. Do not skip a user-facing example merely to make CI green; make executable examples self-contained or use `cont` as appropriate. Be especially careful with shell blocks in repository guidance because `pytest-codeblocks` can execute them and accidentally make the test suite slow or recursive.
 
 When a tutorial calculates a result and visualisation is useful, show the chart in the built documentation rather than only showing plotting code.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,48 @@
+# PAL Documentation Agent Guide
+
+These rules apply to changes under `docs/` in addition to the root `AGENTS.md`.
+
+## Audience and Language
+
+Write for actuaries, quantitative analysts and Python users. Explain what a public function or model means to the user before discussing how it is implemented.
+
+Avoid exposing internal implementation language in user-facing descriptions when it does not help the user. In particular, do not describe ordinary operations in terms of "backend ndarrays", internal wrapper machinery or coupling metadata unless that mechanism is itself the topic of the documentation.
+
+## Mathematical Documentation
+
+- Keep formulas consistent with the implemented parameterisation.
+- Check symbols, parameter domains and limiting cases against code and a reliable reference.
+- Use display mathematics for substantive formulas rather than ASCII approximations.
+- Treat rendered mathematics as part of correctness: a formula that is valid in source but broken in Sphinx is not complete.
+
+## Examples
+
+Prefer small canonical examples that demonstrate one concept clearly. Documentation code should use the public API a normal PAL user should copy.
+
+Executable code blocks should remain compatible with `pytest-codeblocks`. Mark code as skipped only when execution genuinely requires external resources, interactive display, unavailable hardware or another documented reason.
+
+When a tutorial calculates a result and visualisation is useful, show the chart in the built documentation rather than only showing plotting code.
+
+## Charts
+
+Use Plotly for documentation illustrations and PAL's Proteus Plotly styling/template where available. Do not introduce Matplotlib for user-facing documentation charts unless a task explicitly requires it.
+
+Keep Proteus branding subtle and consistent with the existing documentation design.
+
+## API Documentation
+
+Signatures and type annotations are the authoritative source for types. Do not repeat type names in prose merely to duplicate the signature.
+
+Public docstrings should cover:
+
+- the purpose and statistical/actuarial interpretation;
+- non-obvious parameter meaning;
+- return semantics;
+- important exceptions or constraints;
+- references where the implementation depends on a specific algorithm or paper.
+
+## Validation
+
+Build documentation with warnings treated seriously. Also run relevant documentation code-block tests after changing examples or public API documentation.
+
+The AI quick reference at `docs/source/ai_assistants.md` is intentionally concise and should remain a high-density map from common user intentions to canonical PAL API usage.

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,183 +2,121 @@
 
 # Development Guide
 
-This project uses pip for dependency installation and Docker devcontainers for development.
+PAL can be developed in a standard Python environment or in the supplied Docker devcontainers. The devcontainer is convenient for local development but is not a prerequisite for cloud coding agents or other automated environments.
 
-## Getting Started
+Coding agents should read [`AGENTS.md`](../AGENTS.md) before making changes. The project configuration, Makefile and CI workflows are authoritative when prose documentation differs from executable configuration.
 
-### Prerequisites
-- Docker
-- VS Code with [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+## Standard Python setup
 
-### Setup Development Environment
-
-1. **Open in devcontainer**:
-   - Open the project in VS Code
-   - Command Palette → "Dev Containers: Reopen in Container"
-   - Wait for the container to build.
-
-2. **Verify setup**:
-   ```bash
-   python --version
-   pip --version
-   pytest --version
-   ```
-
-The devcontainer installs the project in editable mode with the test, development, and documentation extras:
+Create or activate a Python environment supported by `pyproject.toml`, then install PAL in editable mode with the development extras:
 
 ```bash
-pip install -e ".[test,dev,docs]"
+python -m pip install -e ".[test,dev,docs]"
 ```
 
-## Managing Dependencies
-
-Dependencies are declared in `pyproject.toml` using standard Python project metadata.
-
-- **Core dependencies**: required runtime dependencies such as NumPy, SciPy, Plotly and pandas.
-- **Optional dependencies**:
-  - `gpu`: CUDA support with `cupy-cuda12x`.
-  - `docs`: documentation build dependencies.
-  - `test`: testing tools.
-  - `dev`: development and static-analysis tools.
-
-After changing `pyproject.toml`, reinstall the project and the extras you need. For a full development environment:
+Verify the environment with:
 
 ```bash
-pip install -e ".[test,dev,docs]"
+python --version
+python -m pytest --version
+make help
 ```
 
-For GPU support:
+For GPU support in a compatible CUDA environment:
 
 ```bash
-pip install -e ".[gpu]"
+python -m pip install -e ".[test,dev,docs,gpu]"
 ```
 
-Or combine extras when required:
+## Devcontainer setup
+
+For a reproducible local environment, open the repository in VS Code and choose **Dev Containers: Reopen in Container**. The devcontainer installs the project in editable mode.
+
+The established local container may be named `pal-devcontainer`. If it is already running, commands can also be invoked from the host, for example:
 
 ```bash
-pip install -e ".[test,dev,docs,gpu]"
+docker exec pal-devcontainer make test-fast
 ```
 
-## Versioning
+Do not assume that named container exists in a fresh cloud or CI environment.
 
-Versions are automatically managed from Git tags by `setuptools-scm`; no manual version update is required.
+## Development commands
 
-- `dynamic = ["version"]` in `pyproject.toml` enables dynamic versioning.
-- A tag such as `v1.0.0` produces version `1.0.0`.
-- Commits between releases receive an automatically generated development version.
-
-### Creating a release
-
-1. Tag the release: `git tag v1.0.0`
-2. Push the tag: `git push origin v1.0.0`
-3. Create a GitHub Release from that tag. The release workflow publishes the package to PyPI.
-
-### Check the installed version
-
-```bash
-pip show proteusllp-actuarial-library
-```
-
-## Release Process
-
-### Use PEP 440-Compliant Versions
-
-Use a PEP 440-compliant version format, for example:
-
-- `v0.0.1a1` (alpha)
-- `v0.0.1b1` (beta)
-- `v0.0.1rc1` (release candidate)
-- `v0.0.1.dev1` (development)
-- `v0.0.1.post1` (post-release)
-
-Avoid arbitrary suffixes such as `-test`.
-
-For pre-release versions, use GitHub's "Set as pre-release" option when creating the release.
-
-## Running Tests
-
-### From VS Code Terminal
-
-```bash
-# Run all tests
-pytest
-
-# Run a specific test file
-pytest tests/test_variables.py
-
-# Run with verbose output
-pytest -v
-
-# Run tests with coverage
-pytest --cov=pal
-
-# Run tests in parallel
-pytest -n auto
-
-# Execute documentation code blocks
-pytest --codeblocks
-```
-
-### From VS Code Test Explorer
-
-1. Open the Test Explorer panel.
-2. Click "Configure Python Tests" if prompted.
-3. Select `pytest` as the test framework.
-
-## Static Analysis and Type Checking
-
-PAL uses Pyright for static type checking and Ruff for linting and formatting.
-
-```bash
-make lint
-make format
-make typecheck
-```
-
-The same tools can also be run directly from the activated project environment.
-
-## Development Commands
-
-Run the Makefile commands from inside the devcontainer:
+The `Makefile` is the canonical interface for routine validation:
 
 ```bash
 make help
 make lint
-make format
+make format-check
 make typecheck
+make static-analysis
+make test-fast
 make test
+make check
 make build
 ```
 
-## Container Architecture
+Use focused tests while iterating:
 
-The project uses separate CPU and GPU development containers. Both install PAL into the container using pip in editable mode, so changes to the source tree are immediately available.
+```bash
+pytest tests/test_variables.py
+pytest tests/test_variables.py::test_name
+```
+
+Documentation code blocks can be exercised with `pytest-codeblocks` as configured by the project and CI.
+
+## Dependencies
+
+Dependencies are declared in `pyproject.toml` using standard Python project metadata.
+
+- `gpu`: CUDA/CuPy support.
+- `docs`: documentation build dependencies.
+- `test`: pytest and test tooling.
+- `dev`: linting, type checking, security and development tools.
+
+After changing dependencies, reinstall the relevant editable extras.
+
+## Static analysis
+
+PAL uses Ruff for linting/formatting, Pyright for type checking, Bandit for security checks and Vulture for dead-code detection. Run these through `make static-analysis` so local validation matches project configuration.
+
+## CPU and GPU development
+
+PAL has separate CPU and GPU CI paths. A backend-sensitive change is not fully validated by CPU tests alone. Follow the root and `src/pal/AGENTS.md` guidance and run the relevant GPU workflow or equivalent CUDA tests.
+
+## Versioning and releases
+
+Versions are generated from Git tags by `setuptools-scm`; do not edit a version constant manually.
+
+Use PEP 440-compliant release tags such as:
+
+- `v0.0.1a1`
+- `v0.0.1b1`
+- `v0.0.1rc1`
+- `v0.0.1`
+
+A normal release process is:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+Then create the corresponding GitHub Release. The release workflow publishes the package to PyPI.
 
 ## Troubleshooting
 
-### Dependencies Not Found
-
-Reinstall the editable package with the required extras:
+If dependencies are missing, reinstall the editable package:
 
 ```bash
-pip install -e ".[test,dev,docs]"
+python -m pip install -e ".[test,dev,docs]"
 ```
 
-If the devcontainer itself has changed, rebuild it with "Dev Containers: Rebuild Container".
+If a devcontainer configuration changed, rebuild the container. In a non-container environment, diagnose the Python environment directly rather than attempting to find `pal-devcontainer`.
 
-### Container Won't Start
+## See also
 
-Rebuild the relevant container without cache if necessary.
-
-## See Also
-
-- [Usage Guide](usage.md) - Comprehensive examples and API documentation
-- [Examples](../examples/) - Example scripts showing library usage
-- [Main README](../README.md) - Project overview and installation
-
-## References
-
-- [pip Documentation](https://pip.pypa.io/)
-- [Python Packaging User Guide](https://packaging.python.org/)
-- [Dev Containers Documentation](https://containers.dev/)
-- [VS Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers)
+- [Usage Guide](usage.md)
+- [Examples](../examples/)
+- [Repository agent guide](../AGENTS.md)
+- [Type-system architecture](structure.md)

--- a/docs/source/_ext/pal_llms.py
+++ b/docs/source/_ext/pal_llms.py
@@ -1,0 +1,67 @@
+"""Generate model-friendly documentation entry points for the HTML build."""
+
+from pathlib import Path
+
+DOCS_URL = "https://proteusllp-actuarial-library.readthedocs.io/en/latest/"
+
+LLMS_INDEX = f"""# Proteus Actuarial Library (PAL)
+
+> PAL is an open-source Python library for simulation-based actuarial and financial modelling, including distributions, stochastic variables, copulas, frequency-severity models, reinsurance, risk measures and optional GPU acceleration.
+
+The PyPI distribution is `proteusllp-actuarial-library`; import it in Python as `pal`.
+
+## Start here
+
+- [PAL quick reference for coding assistants]({DOCS_URL}ai_assistants.html): compact mapping from modelling intentions to the public PAL API.
+- [Getting started]({DOCS_URL}tutorials/getting_started.html): core simulation workflow.
+- [API reference]({DOCS_URL}api/modules.html): generated public API documentation.
+
+## Core modelling guides
+
+- [Distributions]({DOCS_URL}tutorials/distributions_guide.html)
+- [Frequency-severity modelling]({DOCS_URL}tutorials/frequency_severity_modelling.html)
+- [Coupling groups and copulas]({DOCS_URL}tutorials/coupling_groups_and_copulas.html)
+- [XoL reinsurance]({DOCS_URL}tutorials/xol_reinsurance.html)
+- [Property exposure rating]({DOCS_URL}tutorials/property_exposure_rating.html)
+- [Risk measures and capital allocation]({DOCS_URL}tutorials/risk_measures_and_allocation.html)
+
+## Development
+
+- [Development guide]({DOCS_URL}development.html)
+- [GitHub repository](https://github.com/ProteusLLP/proteusllp-actuarial-library)
+- [Repository agent instructions](https://github.com/ProteusLLP/proteusllp-actuarial-library/blob/main/AGENTS.md)
+
+## Notes for model/tool use
+
+Prefer documented public APIs and inspect signatures/docstrings rather than guessing names or parameterisations. PAL stochastic objects preserve simulation relationships through coupling groups; avoid replacing PAL operations with raw-array manipulation when that would discard those relationships. Code using the public API should normally remain backend-independent across NumPy and CuPy execution.
+"""
+
+
+def _write_llms_files(app: object, exception: Exception | None) -> None:
+    """Write llms.txt and a concatenated source-document view after a successful build."""
+    if exception is not None:
+        return
+
+    builder = getattr(app, "builder")
+    if getattr(builder, "format", None) != "html":
+        return
+
+    outdir = Path(getattr(app, "outdir"))
+    (outdir / "llms.txt").write_text(LLMS_INDEX, encoding="utf-8")
+
+    env = getattr(app, "env")
+    sections = [LLMS_INDEX, "\n# Full documentation source\n"]
+    for docname in sorted(env.found_docs):
+        source_path = Path(env.doc2path(docname))
+        if not source_path.exists() or source_path.suffix not in {".md", ".rst"}:
+            continue
+        source = source_path.read_text(encoding="utf-8")
+        sections.append(f"\n\n---\n\n## Source: {docname}\n\n{source}")
+
+    (outdir / "llms-full.txt").write_text("".join(sections), encoding="utf-8")
+
+
+def setup(app: object) -> dict[str, bool]:
+    """Register the build-finished hook with Sphinx."""
+    app.connect("build-finished", _write_llms_files)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/source/_ext/pal_llms.py
+++ b/docs/source/_ext/pal_llms.py
@@ -1,6 +1,7 @@
 """Generate model-friendly documentation entry points for the HTML build."""
 
 from pathlib import Path
+from typing import Any, Optional
 
 DOCS_URL = "https://proteusllp-actuarial-library.readthedocs.io/en/latest/"
 
@@ -37,22 +38,20 @@ Prefer documented public APIs and inspect signatures/docstrings rather than gues
 """
 
 
-def _write_llms_files(app: object, exception: Exception | None) -> None:
+def _write_llms_files(app: Any, exception: Optional[Exception]) -> None:
     """Write llms.txt and a concatenated source-document view after a successful build."""
     if exception is not None:
         return
 
-    builder = getattr(app, "builder")
-    if getattr(builder, "format", None) != "html":
+    if getattr(app.builder, "format", None) != "html":
         return
 
-    outdir = Path(getattr(app, "outdir"))
+    outdir = Path(app.outdir)
     (outdir / "llms.txt").write_text(LLMS_INDEX, encoding="utf-8")
 
-    env = getattr(app, "env")
     sections = [LLMS_INDEX, "\n# Full documentation source\n"]
-    for docname in sorted(env.found_docs):
-        source_path = Path(env.doc2path(docname))
+    for docname in sorted(app.env.found_docs):
+        source_path = Path(app.env.doc2path(docname))
         if not source_path.exists() or source_path.suffix not in {".md", ".rst"}:
             continue
         source = source_path.read_text(encoding="utf-8")
@@ -61,7 +60,7 @@ def _write_llms_files(app: object, exception: Exception | None) -> None:
     (outdir / "llms-full.txt").write_text("".join(sections), encoding="utf-8")
 
 
-def setup(app: object) -> dict[str, bool]:
+def setup(app: Any) -> dict[str, bool]:
     """Register the build-finished hook with Sphinx."""
     app.connect("build-finished", _write_llms_files)
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/source/ai_assistants.md
+++ b/docs/source/ai_assistants.md
@@ -1,0 +1,144 @@
+# PAL quick reference for coding assistants
+
+This page is a compact map from common modelling intentions to PAL's public Python API. It is useful for coding assistants and for users who want a terse reminder of the main concepts.
+
+## Install and import
+
+```bash
+pip install proteusllp-actuarial-library
+```
+
+```python
+from pal import config, copulas, distributions, set_random_seed
+```
+
+The PyPI distribution is `proteusllp-actuarial-library`; the installed Python package is `pal`.
+
+## Configure simulations
+
+```python
+config.n_sims = 10_000
+set_random_seed(42)
+```
+
+`config.n_sims` is the default number of Monte Carlo simulations. Use `set_random_seed` when reproducibility matters.
+
+## Generate a stochastic variable
+
+```python
+loss = distributions.LogNormal(mu=14, sigma=0.5).generate()
+```
+
+`generate()` returns a `StochasticScalar` for an ordinary univariate distribution. A `StochasticScalar` represents one simulated value per simulation.
+
+Use PAL's methods for common simulation statistics:
+
+```python
+mean_loss = loss.mean()
+standard_deviation = loss.std()
+var_995 = loss.percentile(99.5)
+```
+
+Prefer `loss.percentile(99.5)` to reaching into `loss.values` and calling `numpy.percentile` unless the raw array is specifically required for another operation.
+
+## Arithmetic and derived variables
+
+Arithmetic is element-wise across simulations:
+
+```python
+expenses = 0.10 * loss
+gross = loss + expenses
+```
+
+Derived variables remain coupled to their inputs. This matters because PAL can later reorder simulations to impose dependence while keeping related quantities aligned.
+
+## Add dependence with a copula
+
+Generate marginal variables first, then apply a copula:
+
+```python
+motor = distributions.LogNormal(mu=14, sigma=0.5).generate()
+property_loss = distributions.LogNormal(mu=15, sigma=0.8).generate()
+
+copula = copulas.GaussianCopula([[1.0, 0.5], [0.5, 1.0]])
+copula.apply([motor, property_loss])
+
+portfolio = motor + property_loss
+```
+
+A copula changes dependence by reordering simulations. It should not change either marginal distribution.
+
+Do not manually reorder `.values` when PAL coupling groups should propagate the reordering to related variables.
+
+## Frequency-severity models
+
+For a random number of random-sized claims:
+
+```python
+from pal.frequency_severity import FrequencySeverityModel
+
+model = FrequencySeverityModel(
+    freq_dist=distributions.Poisson(mean=100),
+    sev_dist=distributions.LogNormal(mu=10, sigma=1.5),
+)
+
+events = model.generate()
+aggregate_loss = events.aggregate()
+```
+
+Use the event-level result when claim-level information matters. Use `aggregate()` for one total loss per simulation.
+
+## Plot a stochastic result
+
+PAL plotting methods return Plotly figures rather than displaying them automatically:
+
+```python
+fig = aggregate_loss.cdf_plot("Aggregate Loss")
+```
+
+Call `fig.show()` only in an interactive environment.
+
+## GPU execution
+
+Install PAL with the GPU extra in a compatible CUDA environment:
+
+```bash
+pip install "proteusllp-actuarial-library[gpu]"
+```
+
+Set `PAL_USE_GPU=1` before importing/running PAL when GPU execution is required. Code using the public PAL API should normally be backend-independent.
+
+Avoid converting PAL/CuPy data to NumPy merely to perform an operation that PAL already supports, because that can introduce expensive device-to-host transfers.
+
+## How to discover an unfamiliar API
+
+Prefer the public API and introspection before guessing a class or parameter name:
+
+```python
+import inspect
+
+from pal import distributions
+
+print(inspect.signature(distributions.Gamma))
+help(distributions.Gamma)
+```
+
+The generated [API reference](api/modules.html) is the authoritative browsable catalogue of documented classes and methods.
+
+Useful conceptual guides are:
+
+- [Getting started](tutorials/getting_started.html)
+- [Distributions guide](tutorials/distributions_guide.html)
+- [Frequency-severity modelling](tutorials/frequency_severity_modelling.html)
+- [Coupling groups and copulas](tutorials/coupling_groups_and_copulas.html)
+- [XoL reinsurance](tutorials/xol_reinsurance.html)
+- [Risk measures and capital allocation](tutorials/risk_measures_and_allocation.html)
+
+## Common mistakes to avoid
+
+- Do not assume similarly named distributions use the same parameterisation as SciPy or another library; inspect PAL's signature and docstring.
+- Do not discard coupling relationships by extracting and rebuilding raw arrays without a reason.
+- Do not assume two generated risks are dependent until a dependence structure has been applied; derived variables, however, remain aligned with their inputs.
+- Do not write CPU-only NumPy conversions into code intended to work on PAL's GPU backend.
+- Do not infer undocumented public APIs from internal helper names. Prefer documented imports and classes.
+- For percentiles and other operations already exposed by `StochasticScalar`, prefer the PAL method because it expresses the modelling intention directly.

--- a/docs/source/ai_assistants.md
+++ b/docs/source/ai_assistants.md
@@ -16,6 +16,8 @@ The PyPI distribution is `proteusllp-actuarial-library`; the installed Python pa
 
 ## Configure simulations
 
+<!--pytest-codeblocks:cont-->
+
 ```python
 config.n_sims = 10_000
 set_random_seed(42)
@@ -25,6 +27,8 @@ set_random_seed(42)
 
 ## Generate a stochastic variable
 
+<!--pytest-codeblocks:cont-->
+
 ```python
 loss = distributions.LogNormal(mu=14, sigma=0.5).generate()
 ```
@@ -32,6 +36,8 @@ loss = distributions.LogNormal(mu=14, sigma=0.5).generate()
 `generate()` returns a `StochasticScalar` for an ordinary univariate distribution. A `StochasticScalar` represents one simulated value per simulation.
 
 Use PAL's methods for common simulation statistics:
+
+<!--pytest-codeblocks:cont-->
 
 ```python
 mean_loss = loss.mean()
@@ -45,6 +51,8 @@ Prefer `loss.percentile(99.5)` to reaching into `loss.values` and calling `numpy
 
 Arithmetic is element-wise across simulations:
 
+<!--pytest-codeblocks:cont-->
+
 ```python
 expenses = 0.10 * loss
 gross = loss + expenses
@@ -55,6 +63,8 @@ Derived variables remain coupled to their inputs. This matters because PAL can l
 ## Add dependence with a copula
 
 Generate marginal variables first, then apply a copula:
+
+<!--pytest-codeblocks:cont-->
 
 ```python
 motor = distributions.LogNormal(mu=14, sigma=0.5).generate()
@@ -74,6 +84,8 @@ Do not manually reorder `.values` when PAL coupling groups should propagate the 
 
 For a random number of random-sized claims:
 
+<!--pytest-codeblocks:cont-->
+
 ```python
 from pal.frequency_severity import FrequencySeverityModel
 
@@ -91,6 +103,8 @@ Use the event-level result when claim-level information matters. Use `aggregate(
 ## Plot a stochastic result
 
 PAL plotting methods return Plotly figures rather than displaying them automatically:
+
+<!--pytest-codeblocks:cont-->
 
 ```python
 fig = aggregate_loss.cdf_plot("Aggregate Loss")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,9 @@
 import os
 import sys
 
-# Add the parent directory to the path so we can import the package
+# Add the source package and local Sphinx extensions to the import path.
 sys.path.insert(0, os.path.abspath("../../src"))
+sys.path.insert(0, os.path.abspath("_ext"))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -31,6 +32,7 @@ version = ".".join(release.split(".")[:2])
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    "pal_llms",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -1,158 +1,116 @@
 <!--pytest-codeblocks:skipfile-->
 # Development Guide
 
-This project uses pip for dependency installation and Docker devcontainers for development.
+PAL can be developed in a standard Python environment or in the supplied Docker devcontainers. The devcontainer is convenient for local development but is not a prerequisite for cloud coding agents or other automated environments.
 
-## Getting Started
+Coding agents should read the repository [`AGENTS.md`](https://github.com/ProteusLLP/proteusllp-actuarial-library/blob/main/AGENTS.md) before making changes. The project configuration, Makefile and CI workflows are authoritative when prose documentation differs from executable configuration.
 
-### Prerequisites
-- Docker
-- VS Code with [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+## Standard Python setup
 
-### Setup Development Environment
-
-1. **Open in devcontainer**:
-   - Open the project in VS Code
-   - Command Palette → "Dev Containers: Reopen in Container"
-   - Wait for the container to build.
-
-2. **Verify setup**:
-   ```bash
-   python --version
-   pip --version
-   pytest --version
-   ```
-
-The devcontainer installs the project in editable mode with the test, development, and documentation extras:
+Create or activate a Python environment supported by `pyproject.toml`, then install PAL in editable mode with the development extras:
 
 ```bash
-pip install -e ".[test,dev,docs]"
+python -m pip install -e ".[test,dev,docs]"
 ```
 
-## Managing Dependencies
+Verify the environment with:
+
+```bash
+python --version
+python -m pytest --version
+make help
+```
+
+For GPU support in a compatible CUDA environment:
+
+```bash
+python -m pip install -e ".[test,dev,docs,gpu]"
+```
+
+## Devcontainer setup
+
+For a reproducible local environment, open the repository in VS Code and choose **Dev Containers: Reopen in Container**. The devcontainer installs the project in editable mode.
+
+The established local container may be named `pal-devcontainer`. If it is already running, commands can also be invoked from the host, for example:
+
+```bash
+docker exec pal-devcontainer make test-fast
+```
+
+Do not assume that named container exists in a fresh cloud or CI environment.
+
+## Development commands
+
+The `Makefile` is the canonical interface for routine validation:
+
+```bash
+make help
+make lint
+make format-check
+make typecheck
+make static-analysis
+make test-fast
+make test
+make check
+make build
+```
+
+Use focused tests while iterating:
+
+```bash
+pytest tests/test_variables.py
+pytest tests/test_variables.py::test_name
+```
+
+Documentation code blocks can be exercised with `pytest-codeblocks` as configured by the project and CI.
+
+## Dependencies
 
 Dependencies are declared in `pyproject.toml` using standard Python project metadata.
 
-- **Core dependencies**: required runtime dependencies such as NumPy, SciPy, Plotly and pandas.
-- **Optional dependencies**:
-  - `gpu`: CUDA support with `cupy-cuda12x`.
-  - `docs`: documentation build dependencies.
-  - `test`: testing tools.
-  - `dev`: development and static-analysis tools.
+- `gpu`: CUDA/CuPy support.
+- `docs`: documentation build dependencies.
+- `test`: pytest and test tooling.
+- `dev`: linting, type checking, security and development tools.
 
-After changing `pyproject.toml`, reinstall the project and the extras you need. For a full development environment:
+After changing dependencies, reinstall the relevant editable extras.
 
-```bash
-pip install -e ".[test,dev,docs]"
-```
+## Static analysis
 
-For GPU support:
+PAL uses Ruff for linting/formatting, Pyright for type checking, Bandit for security checks and Vulture for dead-code detection. Run these through `make static-analysis` so local validation matches project configuration.
 
-```bash
-pip install -e ".[gpu]"
-```
+## CPU and GPU development
 
-Or combine extras when required:
+PAL has separate CPU and GPU CI paths. A backend-sensitive change is not fully validated by CPU tests alone. Follow the repository agent guidance and run the relevant GPU workflow or equivalent CUDA tests.
 
-```bash
-pip install -e ".[test,dev,docs,gpu]"
-```
+## Versioning and releases
 
-## Versioning
+Versions are generated from Git tags by `setuptools-scm`; do not edit a version constant manually.
 
-Versions are automatically managed from Git tags by `setuptools-scm`; no manual version update is required.
+Use PEP 440-compliant release tags such as `v0.0.1a1`, `v0.0.1b1`, `v0.0.1rc1` or `v0.0.1`.
 
-- `dynamic = ["version"]` in `pyproject.toml` enables dynamic versioning.
-- A tag such as `v1.0.0` produces version `1.0.0`.
-- Commits between releases receive an automatically generated development version.
-
-### Creating a release
-
-1. Tag the release: `git tag v1.0.0`
-2. Push the tag: `git push origin v1.0.0`
-3. Create a GitHub Release from that tag. The release workflow publishes the package to PyPI.
-
-### Check the installed version
+A normal release process is:
 
 ```bash
-pip show proteusllp-actuarial-library
+git tag v1.0.0
+git push origin v1.0.0
 ```
 
-## Release Process
-
-### Use PEP 440-Compliant Versions
-
-Use a PEP 440-compliant version format, for example:
-
-- `v0.0.1a1` (alpha)
-- `v0.0.1b1` (beta)
-- `v0.0.1rc1` (release candidate)
-- `v0.0.1.dev1` (development)
-- `v0.0.1.post1` (post-release)
-
-Avoid arbitrary suffixes such as `-test`.
-
-For pre-release versions, use GitHub's "Set as pre-release" option when creating the release.
-
-## Running Tests
-
-### From VS Code Terminal
-
-```bash
-# Run all tests
-pytest
-
-# Run a specific test file
-pytest tests/test_variables.py
-
-# Run with verbose output
-pytest -v
-
-# Run tests with coverage
-pytest --cov=pal
-
-# Run tests in parallel
-pytest -n auto
-
-# Execute documentation code blocks
-pytest --codeblocks
-```
-
-### From VS Code Test Explorer
-
-1. Open the Test Explorer panel.
-2. Click "Configure Python Tests" if prompted.
-3. Select `pytest` as the test framework.
-
-## Container Architecture
-
-The project uses separate CPU and GPU development containers. Both install PAL into the container using pip in editable mode, so changes to the source tree are immediately available.
+Then create the corresponding GitHub Release. The release workflow publishes the package to PyPI.
 
 ## Troubleshooting
 
-### Dependencies Not Found
-
-Reinstall the editable package with the required extras:
+If dependencies are missing, reinstall the editable package:
 
 ```bash
-pip install -e ".[test,dev,docs]"
+python -m pip install -e ".[test,dev,docs]"
 ```
 
-If the devcontainer itself has changed, rebuild it with "Dev Containers: Rebuild Container".
+If a devcontainer configuration changed, rebuild the container. In a non-container environment, diagnose the Python environment directly rather than attempting to find `pal-devcontainer`.
 
-### Container Won't Start
+## See also
 
-Rebuild the relevant container without cache if necessary.
-
-## See Also
-
-- [Usage Guide](usage.md) - Comprehensive examples and API documentation
-- [Examples](https://github.com/ProteusLLP/proteusllp-actuarial-library/tree/main/examples) - Example scripts showing library usage
-- [Main README](https://github.com/ProteusLLP/proteusllp-actuarial-library) - Project overview and installation
-
-## References
-
-- [pip Documentation](https://pip.pypa.io/)
-- [Python Packaging User Guide](https://packaging.python.org/)
-- [Dev Containers Documentation](https://containers.dev/)
-- [VS Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers)
+- [Usage Guide](usage.md)
+- [Examples](https://github.com/ProteusLLP/proteusllp-actuarial-library/tree/main/examples)
+- [Repository agent guide](https://github.com/ProteusLLP/proteusllp-actuarial-library/blob/main/AGENTS.md)
+- [Type-system architecture](https://github.com/ProteusLLP/proteusllp-actuarial-library/blob/main/docs/structure.md)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -117,6 +117,7 @@ A small model, end to end
    :hidden:
 
    usage
+   ai_assistants
 
 .. toctree::
    :maxdepth: 2
@@ -153,5 +154,4 @@ A small model, end to end
 
    development
    contributing
-   development
    license

--- a/src/pal/AGENTS.md
+++ b/src/pal/AGENTS.md
@@ -1,0 +1,61 @@
+# PAL Source Agent Guide
+
+These rules apply to changes under `src/pal/` in addition to the root `AGENTS.md`.
+
+## Public API
+
+- Treat documented public classes, functions, methods and import paths as compatibility-sensitive.
+- User-facing docstrings should explain actuarial/statistical behaviour, not internal backend mechanics.
+- Prefer terminology a PAL user would recognise. For example, `StochasticScalar.mean()` takes the mean across simulations; users do not need implementation language such as "backend ndarray".
+- Keep signatures, type annotations and docstrings mutually consistent.
+- If a symbol is intended to be public, make its exposure deliberate rather than relying on accidental wildcard-import behaviour.
+
+## Stochastic Semantics and Coupling
+
+PAL tracks relationships between simulated variables through coupling groups. Preserve those relationships when transforming or wrapping results.
+
+When a function accepts stochastic parameters or returns a stochastic object:
+
+- verify that derived results remain in the correct coupling groups;
+- do not silently detach distribution parameters from their existing dependencies;
+- preserve simulation alignment through arithmetic, transformations and copula reordering;
+- add tests that would fail if coupling metadata were lost.
+
+## CPU and GPU Behaviour
+
+Backend support is a behavioural contract, not just an implementation detail.
+
+- CPU and GPU paths should implement the same statistical model and public semantics.
+- Avoid unnecessary host/device transfers. Do not convert CuPy arrays to NumPy merely to call a convenient CPU implementation when a practical GPU implementation exists.
+- Keep random-number generation reproducible according to PAL's established backend conventions.
+- Backend-specific optimisations must not introduce undocumented special cases tied to isolated parameter values.
+- Validate numerical accuracy as well as speed when replacing mathematical kernels.
+
+## Numerical and Distribution Code
+
+For distributions, copulas, special functions and risk calculations:
+
+- derive behaviour from the mathematical definition rather than fitting tests to the implementation;
+- test against theoretical moments, known values, trusted reference implementations or literature examples where practical;
+- include boundary and limiting cases that matter mathematically;
+- pay particular attention to tail probabilities, inverse CDFs and numerically extreme parameters;
+- keep mathematical documentation consistent with the implemented parameterisation.
+
+Self-consistency checks such as `cdf(ppf(p)) == p` are useful but are not sufficient evidence of correctness on their own.
+
+## Type-System Architecture
+
+Read `docs/structure.md` before changing protocols or core types.
+
+Critical invariants include:
+
+- `types.py` defines abstractions and must not import concrete PAL implementations;
+- protocols are for structural typing, not runtime inheritance;
+- higher architectural layers may depend on lower layers, not the reverse;
+- avoid solving type errors by introducing circular imports or broad `Any`/`type: ignore` escapes.
+
+Use a narrow, documented type ignore only when the type checker or a third-party stub cannot express correct behaviour.
+
+## Imports and Initialisation
+
+PAL has some established import-order constraints. Before adding package-level imports or changing `__init__.py`, inspect the existing dependency chain and ensure import-time cycles are not introduced.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,49 @@
+# PAL Test Agent Guide
+
+These rules apply to changes under `tests/` in addition to the root `AGENTS.md`.
+
+## Testing Philosophy
+
+PAL is a numerical actuarial library. Tests should establish that an implementation represents the intended mathematics and stochastic semantics, not merely that the code is internally self-consistent.
+
+## Numerical Tests
+
+For distributions, copulas, special functions and risk calculations, prefer one or more independent checks:
+
+- closed-form moments or probabilities;
+- published numerical examples;
+- SciPy, Boost or another trusted implementation where parameterisations agree;
+- direct numerical integration or high-precision calculation;
+- simulation checks when no exact benchmark is practical.
+
+Self-consistency tests such as `cdf(ppf(p)) == p` are useful secondary checks, but should not be the only numerical validation.
+
+Include important boundary, limiting and tail cases. Choose tolerances from expected numerical error rather than simply loosening them until a test passes.
+
+## Stochastic and Coupling Tests
+
+When code accepts stochastic parameters or returns PAL stochastic objects, test more than the output values. Verify that:
+
+- coupling groups are preserved or combined as intended;
+- dependent inputs remain aligned after transformations;
+- copula reordering propagates to derived variables correctly;
+- wrapper/helper functions do not detach parameters or results from existing coupling relationships.
+
+## CPU/GPU Tests
+
+For backend-sensitive changes:
+
+- test the CPU implementation normally;
+- exercise the GPU implementation in GPU CI where available;
+- compare CPU and GPU statistical/numerical results within appropriate tolerances;
+- add a regression test for unnecessary host/device conversion when the change is specifically about backend efficiency and it can be tested robustly.
+
+Do not make ordinary CPU tests require CuPy or CUDA.
+
+## Reproducibility
+
+Use PAL's established seed/configuration helpers rather than global ad-hoc random state. Keep tests deterministic unless the test is explicitly statistical; statistical tests should use stable sample sizes and tolerances chosen to avoid flaky CI.
+
+## Scope
+
+Prefer focused tests close to the changed behaviour. Add broad integration tests only when they protect an important cross-module contract that unit tests cannot capture.


### PR DESCRIPTION
## Summary

This PR adds a first-pass AI accessibility layer for both PAL users and coding agents.

### Repository / development agents

- adds canonical root `AGENTS.md` guidance
- adds scoped guidance for `src/pal/`, `tests/`, and `docs/`
- adds `.github/copilot-instructions.md`
- reduces `CLAUDE.md` to a pointer to the canonical cross-tool instructions
- aligns `STYLE_GUIDE.md` with the actual Ruff/Pyright/Make configuration
- makes the development guide usable in ordinary cloud Python environments as well as the devcontainer

The agent guidance captures PAL-specific invariants including coupling-group preservation, CPU/GPU semantic equivalence, avoiding unnecessary device transfers, type-system dependency direction, and independent numerical validation.

### AI using the installed package

- adds a compact `PAL quick reference for coding assistants` page mapping common modelling intentions to canonical public API usage
- links it from the Sphinx documentation and README
- adds a zero-dependency Sphinx extension that emits `/llms.txt` and `/llms-full.txt` in HTML builds

## Scope

This is intentionally documentation/tooling only. It does not change PAL's numerical implementation or runtime public API. A later PR can address public namespace introspection (`__all__`) and a generated API manifest separately.

## Validation

- Sphinx documentation build: passed
- rendered mathematics validation: passed
- static analysis: passed
- Python 3.11/3.12/3.13 test matrix: running at time of draft update
- GPU workflow: running at time of draft update

The connector runtime cannot clone GitHub directly, so repository CI is the execution/validation source for this draft.