### PR TITLE
Add Python 3.14 and 3.15 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@
 #
 # Jobs:
 # - static-analysis: Runs linting/type checking on Python 3.13
-# - test: Runs pytest with coverage on Python 3.12 and 3.13 (matrix)
+# - test: Runs pytest with coverage on Python 3.11 through 3.15 (matrix)
 # - docs-math: Builds the documentation and validates rendered mathematics
 # - build: Builds Python packages using standard build tool
 # - pypi-publish: Publishes to PyPI using trusted publishing (release only)
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11","3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.15"]
       fail-fast: false
 
     steps:
@@ -64,6 +64,7 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install dependencies
         run: pip install -e ".[test]"

--- a/docs/source/ai_assistants.md
+++ b/docs/source/ai_assistants.md
@@ -120,6 +120,8 @@ Call `fig.show()` only in an interactive environment.
 
 Install PAL with the GPU extra in a compatible CUDA environment:
 
+<!--pytest-codeblocks:skip-->
+
 ```bash
 pip install "proteusllp-actuarial-library[gpu]"
 ```

--- a/mirror-package/pyproject.toml
+++ b/mirror-package/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 requires-python = ">=3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 requires-python = ">=3.9"
 dependencies = [


### PR DESCRIPTION
## Summary
- add Python 3.14 and 3.15 to the CI test matrix
- allow prereleases so Python 3.15 RCs are tested before the final release
- advertise Python 3.14 and 3.15 support in both package metadata files

Python 3.15 is currently in release-candidate phase, so `allow-prereleases: true` lets the existing `3.15` matrix entry work now and continue using the final release once it becomes generally available.